### PR TITLE
Fix bugs PIC and PS/2 driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ASMFLAGS := -f elf32
 LDFLAGS  := -m elf_i386 -T $(SRC_DIR)/linker.ld -nostdlib
 
 SRCS :=						\
+	drivers/debug.c			\
 	drivers/gdt.c			\
 	drivers/idt.c			\
 	drivers/interrupt.asm	\
@@ -44,7 +45,7 @@ iso: kernel
 	grub-mkrescue -o $(BUILD_DIR)/ChoacuryOS.iso $(ISO_DIR)
 
 run: iso
-	qemu-system-x86_64 -cdrom $(BUILD_DIR)/ChoacuryOS.iso -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
+	qemu-system-x86_64 -cdrom $(BUILD_DIR)/ChoacuryOS.iso -serial stdio -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
 
 clean:
 	rm -rf $(BUILD_DIR) $(ISO_DIR)

--- a/src/drivers/critical.h
+++ b/src/drivers/critical.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/* Enter critical section, disables interrupts */
+#define ENTER_CRITICAL() u32 flags_ ## __func__; asm volatile("pushf; cli; pop %0" : "=r"(flags_ ## __func__) :: "memory", "cc")
+
+/* Leave critical section, re-enables interrupts if they were on when entering */
+#define LEAVE_CRITICAL() asm volatile("push %0; popf" :: "rm"(flags_ ## __func__) : "memory", "cc")

--- a/src/drivers/debug.c
+++ b/src/drivers/debug.c
@@ -1,0 +1,23 @@
+#include "debug.h"
+#include "ports.h"
+
+void dprint(const char* message)
+{
+    for (int i = 0; message[i]; i++) {
+        port_byte_out(0x3F8, message[i]);
+    }
+}
+
+void dprintln(const char* message)
+{
+    dprint(message);
+    dprint("\r\n");
+}
+
+void dprintbyte(u8 byte) {
+    char buffer[3];
+    buffer[0] = ((byte >>   4) < 10) ? (byte >>   4) + '0' : (byte >>   4) - 10 + 'a';
+    buffer[1] = ((byte & 0x0F) < 10) ? (byte & 0x0F) + '0' : (byte & 0x0F) - 10 + 'a';
+    buffer[2] = '\0';
+    dprint(buffer);
+}

--- a/src/drivers/debug.h
+++ b/src/drivers/debug.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "types.h"
+
+void dprint(const char* message);
+void dprintln(const char* message);
+void dprintbyte(u8);

--- a/src/drivers/idt.c
+++ b/src/drivers/idt.c
@@ -78,13 +78,18 @@ void c_isr_handler(u8 isr, u32) {
 }
 
 void c_irq_handler(u8 irq) {
-    irq_handler_t handler = irq_handlers[irq];
-    if (handler == 0) {
-        k_printf("no handler for irq", 0, TC_YELLO);
+    /* Spurious interrupt */
+    if (!pic_is_in_service(irq)) {
         return;
     }
 
-    handler();
+    irq_handler_t handler = irq_handlers[irq];
+    if (handler == 0) {
+        k_printf("no handler for irq", 0, TC_YELLO);
+    } else {
+        handler();
+    }
+
     pic_send_eoi(irq);
 }
 

--- a/src/drivers/pic.c
+++ b/src/drivers/pic.c
@@ -19,6 +19,7 @@
 #define ICW4_BUF_MASTER 0x0C /* Buffered mode/master */
 #define ICW4_SFNM       0x10 /* Special fully nested (not) */
 
+#define PIC_CMD_ISR 0x0B
 #define PIC_CMD_EOI 0x20
 
 void pic_init() {
@@ -39,7 +40,7 @@ void pic_init() {
     port_byte_out(PIC_PORT_DATA_SLAVE,  ICW4_8086);
 
     /* Initially mask everything but slave */
-    port_byte_out(PIC_PORT_DATA_MASTER, 0xFD);
+    port_byte_out(PIC_PORT_DATA_MASTER, 0xFB);
     port_byte_out(PIC_PORT_DATA_SLAVE,  0xFF);
 }
 
@@ -61,4 +62,14 @@ void pic_send_eoi(u8 irq) {
         port_byte_out(PIC_PORT_CMD_SLAVE, PIC_CMD_EOI);
     }
     port_byte_out(PIC_PORT_CMD_MASTER, PIC_CMD_EOI);
+}
+
+bool pic_is_in_service(u8 irq) {
+    u16 port = PIC_PORT_CMD_MASTER;
+    if (irq >= 8) {
+        port = PIC_PORT_CMD_SLAVE;
+        irq -= 8;
+    }
+    port_byte_out(port, PIC_CMD_ISR);
+    return port_byte_in(port) & (1 << irq);
 }

--- a/src/drivers/pic.h
+++ b/src/drivers/pic.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include <stdbool.h>
 
 /* Initialize PIC. This has to be called once during kernel initialization */
 void pic_init();
@@ -10,3 +11,5 @@ void pic_unmask(u8 irq);
 
 /* Used to send end of interrupt to PIC */
 void pic_send_eoi(u8 irq);
+
+bool pic_is_in_service(u8 irq);

--- a/src/drivers/ps2.c
+++ b/src/drivers/ps2.c
@@ -1,8 +1,10 @@
+#include "critical.h"
+#include "debug.h"
 #include "idt.h"
 #include "pic.h"
+#include "pit.h"
 #include "ports.h"
 #include "ps2.h"
-#include "vga.h"
 
 #define PS2_PORT_DATA       0x60
 #define PS2_PORT_STATUS     0x64
@@ -39,100 +41,207 @@
 #define PS2_INTERRUPT_FIRST     1
 #define PS2_INTERRUPT_SECOND    12
 
+#define PS2_STATE_NORMAL	0
+#define PS2_STATE_WAIT_ACK	1
+#define PS2_STATE_WAIT_RESP	2
+
+static const u64 s_timeout_ms = 100;
+
 static ps2_device_t s_devices[2];
 
-static void ps2_controller_send_command(u8 command) {
-    port_byte_out(PS2_PORT_COMMAND, command);
-}
+typedef struct {
+    ps2_device_t* device;
+    u8 data[2];
+    u8 data_size;
+    u8 data_sent;
+    u8 resp_size;
+    u8 state;
+} ps2_command_t;
 
-static void ps2_controller_send_command_with_data(u8 command, u8 data) {
-    port_byte_out(PS2_PORT_COMMAND, command);
-    while (port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_INPUT) {
-        continue;
+static ps2_command_t s_command_queue[PS2_COMMAND_QUEUE_SIZE];
+static u8 s_command_queue_read  = 0;
+static u8 s_command_queue_write = 0;
+
+static int ps2_send_byte(u16 port, u8 data) {
+    u64 timeout = pit_current_time_ms() + s_timeout_ms;
+    while (pit_current_time_ms() < timeout) {
+        if (port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_INPUT) {
+            continue;
+        }
+        port_byte_out(port, data);
+        return 0;
     }
-    port_byte_out(PS2_PORT_DATA, data);
+    return -1;
 }
 
-static u8 ps2_controller_read_byte() {
-    while (!(port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_OUTPUT)) {
-        continue;
+static int ps2_read_byte() {
+    u64 timeout = pit_current_time_ms() + s_timeout_ms;
+    while (pit_current_time_ms() < timeout) {
+        if (!(port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_OUTPUT)) {
+            continue;
+        }
+        return port_byte_in(PS2_PORT_DATA);
     }
-    return port_byte_in(PS2_PORT_DATA);
+    return -1;
 }
 
-void ps2_device_send_byte(ps2_device_t* device, u8 byte) {
+static int ps2_controller_send_command(u8 command) {
+    if (ps2_send_byte(PS2_PORT_COMMAND, command) == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+static int ps2_controller_send_command_with_data(u8 command, u8 data) {
+    if (ps2_send_byte(PS2_PORT_COMMAND, command) == -1) {
+        return -1;
+    }
+    if (ps2_send_byte(PS2_PORT_DATA, data) == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+static int ps2_device_send_byte(ps2_device_t* device, u8 byte) {
     if (device == &s_devices[1]) {
-        ps2_controller_send_command(PS2_COMMAND_WRITE_TO_SECOND);
+        if (ps2_send_byte(PS2_PORT_COMMAND, PS2_COMMAND_WRITE_TO_SECOND) == -1) {
+            return -1;
+        }
     }
-    /* FIXME: timeout */
-    while (port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_INPUT) {
-        continue;
+    if (ps2_send_byte(PS2_PORT_DATA, byte) == -1) {
+        return -1;
     }
-    port_byte_out(PS2_PORT_DATA, byte);
+    return 0;
 }
 
-static u8 ps2_device_read_byte(ps2_device_t*) {
-    /* FIXME: timeout */
-    while (!(port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_OUTPUT)) {
-        continue;
+static int ps2_device_send_byte_and_wait_ack(ps2_device_t* device, u8 byte) {
+    for (;;) {
+        int resp = ps2_device_send_byte(device, byte);
+        if (resp == -1) {
+            return -1;
+        }
+    
+        resp = ps2_read_byte();
+        if (resp == -1)
+            return -1;
+        if (resp == PS2_DEVICE_RESEND)
+            continue;
+        if (resp == PS2_DEVICE_ACK)
+            break;
+        dprintln("PS/2 Controller: expected ACK");
     }
-    return port_byte_in(PS2_PORT_DATA);
+    return 0;
 }
 
-static void ps2_device_wait_ack(ps2_device_t* device) {
-    /* FIXME: timeout */
-    while (ps2_device_read_byte(device) != PS2_DEVICE_ACK) {
-        continue;
-    }
-}
-
-static void ps2_update_device(ps2_device_t* device) {
-    if (device->type == PS2_TYPE_NONE) {
+static void ps2_update_command_queue() {
+    ENTER_CRITICAL();
+    if (s_command_queue_read == s_command_queue_write) {
+        LEAVE_CRITICAL();
         return;
     }
-    if (device->command_queue_read == device->command_queue_write) {
+    ps2_command_t* command = &s_command_queue[s_command_queue_read];
+    LEAVE_CRITICAL();
+
+    if (command->state != PS2_STATE_NORMAL) {
         return;
     }
-    device->state = PS2_STATE_WAIT_ACK;
-    ps2_device_send_byte(device, device->command_queue[device->command_queue_read]);
+
+    command->state = PS2_STATE_WAIT_ACK;
+    if (ps2_device_send_byte(command->device, command->data[command->data_sent]) == -1) {
+        dprint("PS/2 Controller: command send timeout");
+        command->state = PS2_STATE_NORMAL;
+    }
 }
 
-void ps2_device_append_command_queue(ps2_device_t* device, u8 byte) {
-    device->command_queue[device->command_queue_write] = byte;
-    device->command_queue_write = (device->command_queue_write + 1) % PS2_COMMAND_QUEUE_SIZE;
+void ps2_device_append_command_queue(ps2_device_t* device, u8 byte, u8 response_size) {
+    ENTER_CRITICAL();
+    if ((s_command_queue_write + 1) % PS2_COMMAND_QUEUE_SIZE == s_command_queue_read) {
+        dprintln("PS/2 Controller: command queue full, ignoring command");
+        LEAVE_CRITICAL();
+        return;
+    }
+    ps2_command_t* command = &s_command_queue[s_command_queue_write];
+    s_command_queue_write = (s_command_queue_write + 1) % PS2_COMMAND_QUEUE_SIZE;
+    LEAVE_CRITICAL();
+
+    command->device = device;
+    command->data[0] = byte;
+    command->data[1] = 0x00;
+    command->data_size = 1;
+    command->data_sent = 0;
+    command->resp_size = response_size;
+    command->state = PS2_STATE_NORMAL;
+}
+
+void ps2_device_append_command_queue_with_data(ps2_device_t* device, u8 byte0, u8 byte1, u8 response_size) {
+    ENTER_CRITICAL();
+    if ((s_command_queue_write + 1) % PS2_COMMAND_QUEUE_SIZE == s_command_queue_read) {
+        dprintln("PS/2 Controller: command queue full, ignoring command");
+        LEAVE_CRITICAL();
+        return;
+    }
+    ps2_command_t* command = &s_command_queue[s_command_queue_write];
+    s_command_queue_write = (s_command_queue_write + 1) % PS2_COMMAND_QUEUE_SIZE;
+    LEAVE_CRITICAL();
+
+    command->device = device;
+    command->data[0] = byte0;
+    command->data[1] = byte1;
+    command->data_size = 2;
+    command->data_sent = 0;
+    command->resp_size = response_size;
+    command->state = PS2_STATE_NORMAL;
 }
 
 static void ps2_irq_handler(ps2_device_t* device) {
-    u8 byte = ps2_device_read_byte(device);
+    u8 byte = port_byte_in(PS2_PORT_DATA);
 
-    if (device->state == PS2_STATE_WAIT_ACK) {
-        switch (byte) {
-			case PS2_DEVICE_ACK:
-				device->command_queue_read = (device->command_queue_read + 1) % PS2_COMMAND_QUEUE_SIZE;
-				device->state = PS2_STATE_NORMAL;
-				break;
-			case PS2_DEVICE_RESEND:
-				device->state = PS2_STATE_NORMAL;
-				break;
-			default:
-				k_printf("PS/2 device: unhandeled byte", 0, TC_LRED);
-				break;
-		}
-    } else {
+    bool handle_command = true;
+    if (s_command_queue_read == s_command_queue_write)
+        handle_command = false;
+    else if (s_command_queue[s_command_queue_read].device != device)
+        handle_command = false;
+    else if (s_command_queue[s_command_queue_read].state == PS2_STATE_NORMAL)
+        handle_command = false;
+
+    bool send_to_device = !handle_command;
+
+    if (handle_command) {
+        ps2_command_t* command = &s_command_queue[s_command_queue_read];
+        if (command->state == PS2_STATE_WAIT_ACK) {
+            if (byte == PS2_DEVICE_ACK) {
+                command->data_sent++;
+                if (command->data_sent < command->data_size) {
+                    command->state = PS2_STATE_NORMAL;
+                } else if (command->resp_size > 0) {
+                    command->state = PS2_STATE_WAIT_RESP;
+                } else {
+                    s_command_queue_read++;
+                }
+            } else if (byte == PS2_DEVICE_RESEND) {
+				command->state = PS2_STATE_NORMAL;
+            }
+        } else if (command->state == PS2_STATE_WAIT_RESP) {
+            if (--command->resp_size <= 0) {
+                s_command_queue_read++;
+                send_to_device = true;
+            }
+        }
+    }
+
+    if (send_to_device) {
         device->byte_buffer[device->byte_buffer_len++] = byte;
         switch (device->type) {
             case PS2_TYPE_KEYBOARD:
                 ps2_keyboard_new_byte(device);
                 break;
             default:
-                k_printf("Interrupt from uninitialized device", 0, TC_LRED);
+                dprintln("PS/2 Controller: interrupt from uninitialized device");
                 break;
         }
     }
 
-    if (device->state == PS2_STATE_NORMAL) {
-        ps2_update_device(device);
-    }
+    ps2_update_command_queue();
 }
 
 static void ps2_irq1_handler() {
@@ -145,9 +254,6 @@ static void ps2_irq2_handler() {
 
 static void ps2_zero_device(ps2_device_t* device) {
     device->type = PS2_TYPE_NONE;
-	device->state = PS2_STATE_NORMAL;
-    device->command_queue_read = 0;
-    device->command_queue_write = 0;
     device->byte_buffer_len = 0;
     device->event_queue_len = 0;
 }
@@ -156,6 +262,8 @@ ps2_device_t* ps2_get_device(u8 index) {
     return &s_devices[index];
 }
 
+#define TRY(expr) ({ int ret = expr; if (ret == -1) { dprintln("PS/2 Controller: timeout"); return; }; ret; })
+
 void ps2_init() {
     ps2_zero_device(&s_devices[0]);
     ps2_zero_device(&s_devices[1]);
@@ -163,34 +271,36 @@ void ps2_init() {
     /* FIXME: Parse ACPI tables to confirm that PS/2 actually exists */
 
     /* Disable devices */
-    ps2_controller_send_command(PS2_COMMAND_DISABLE_FIRST);
-    ps2_controller_send_command(PS2_COMMAND_DISABLE_SECOND);
+    TRY(ps2_controller_send_command(PS2_COMMAND_DISABLE_FIRST));
+    TRY(ps2_controller_send_command(PS2_COMMAND_DISABLE_SECOND));
 
     /* Flush data in controller */
-    while (port_byte_in(PS2_PORT_STATUS) & PS2_STATUS_OUTPUT)
-        port_byte_in(PS2_PORT_DATA);
-
-    /* Read current config and turn off translation and interrupts */
-    ps2_controller_send_command(PS2_COMMAND_READ_CONFIG);
-    u8 config = ps2_controller_read_byte();
-    config &= PS2_CONFIG_INTERRUPT_FIRST;
-    config &= PS2_CONFIG_INTERRUPT_SECOND;
-    config &= PS2_CONFIG_TRANSLATION_FIRST;
-    ps2_controller_send_command_with_data(PS2_COMMAND_WRITE_CONFIG, config);
-
-    /* Perform self test */
-    ps2_controller_send_command(PS2_COMMAND_TEST_CONTROLLER);
-    if (ps2_controller_read_byte() != 0x55) {
-        k_printf("PS2 controller self test failed, abort intialiation", 0, TC_LRED);
-        return;
+    while (ps2_read_byte() != -1) {
+        continue;
     }
 
-    /* Determine if we have one or two ports */
+    /* Read current config and turn off translation and interrupts */
+    TRY(ps2_controller_send_command(PS2_COMMAND_READ_CONFIG));
+    u8 config = ps2_read_byte();
+    config &= ~PS2_CONFIG_INTERRUPT_FIRST;
+    config &= ~PS2_CONFIG_INTERRUPT_SECOND;
+    config &= ~PS2_CONFIG_TRANSLATION_FIRST;
+    TRY(ps2_controller_send_command_with_data(PS2_COMMAND_WRITE_CONFIG, config));
+
+    /* Perform self test */
+    TRY(ps2_controller_send_command(PS2_COMMAND_TEST_CONTROLLER));
+    if (TRY(ps2_read_byte()) != 0x55) {
+        dprintln("PS2 Controller: self test failed, abort intialiation");
+        return;
+    }
+    /* NOTE: controller might reset config, so resend it */
+    TRY(ps2_controller_send_command_with_data(PS2_COMMAND_WRITE_CONFIG, config));
+
     bool valid_ports[] = { true, false };
     if (config & PS2_CONFIG_CLOCK_SECOND) {
         ps2_controller_send_command(PS2_COMMAND_ENABLE_SECOND);
         ps2_controller_send_command(PS2_COMMAND_READ_CONFIG);
-        if (ps2_controller_read_byte() & PS2_CONFIG_CLOCK_SECOND) {
+        if (!(ps2_read_byte() & PS2_CONFIG_CLOCK_SECOND)) {
             ps2_controller_send_command(PS2_COMMAND_DISABLE_SECOND);
             valid_ports[1] = true;
         }
@@ -198,15 +308,18 @@ void ps2_init() {
 
     /* Perform interface tests */
     for (int i = 0; i < 2; i++) {
-        if (valid_ports[i]) {
-            ps2_controller_send_command(i == 0 ? PS2_COMMAND_TEST_FIRST : PS2_COMMAND_TEST_SECOND);
-            if (ps2_controller_read_byte() != PS2_DEVICE_TEST_PASS) {
-                valid_ports[i] = false;
-            }
+        if (!valid_ports[i]) {
+            continue;
+        }
+
+        TRY(ps2_controller_send_command(i == 0 ? PS2_COMMAND_TEST_FIRST : PS2_COMMAND_TEST_SECOND));
+        if (TRY(ps2_read_byte()) != PS2_DEVICE_TEST_PASS) {
+            dprintln("PS2 Controller: port self test failed");
+            valid_ports[i] = false;
         }
     }
     if (!valid_ports[0] && !valid_ports[1]) {
-        k_printf("PS2 controller has no devices", 0, TC_YELLO);
+        dprintln("PS2 Controller: no devices");
         return;
     }
 
@@ -216,36 +329,37 @@ void ps2_init() {
             continue;
         }
 
-        ps2_controller_send_command(i == 0 ? PS2_COMMAND_ENABLE_FIRST : PS2_COMMAND_ENABLE_SECOND);
+        TRY(ps2_controller_send_command(i == 0 ? PS2_COMMAND_ENABLE_FIRST : PS2_COMMAND_ENABLE_SECOND));
 
-        ps2_device_send_byte(&s_devices[i], PS2_DEVICE_COMMAND_DISABLE_SCANNING);
-        ps2_device_wait_ack(&s_devices[i]);
-
-        ps2_device_send_byte(&s_devices[i], PS2_DEVICE_COMMAND_RESET);
-        ps2_device_wait_ack(&s_devices[i]);
-
-        ps2_device_send_byte(&s_devices[i], PS2_DEVICE_COMMAND_DISABLE_SCANNING);
-        ps2_device_wait_ack(&s_devices[i]);
-    }
-
-    /* Identify devices */
-    for (int i = 0; i < 2; i++) {
-        if (!valid_ports[i]) {
+        TRY(ps2_device_send_byte_and_wait_ack(&s_devices[i], PS2_DEVICE_COMMAND_RESET));
+        while (ps2_read_byte() != -1) {
             continue;
         }
-        
-        ps2_device_send_byte(&s_devices[i], PS2_DEVICE_COMMAND_IDENTIFY);
-        ps2_device_wait_ack(&s_devices[i]);
+
+        TRY(ps2_device_send_byte_and_wait_ack(&s_devices[i], PS2_DEVICE_COMMAND_DISABLE_SCANNING));
+
+        TRY(ps2_device_send_byte_and_wait_ack(&s_devices[i], PS2_DEVICE_COMMAND_IDENTIFY));
 
         u8 response[2];
+        u8 response_size = 0;
 
-        /* FIXME: some devices respond with only 1 byte. Timeout will be needed for this */
+        dprint("PS2 Controller: ");
         for (int j = 0; j < 2; j++) {
-            response[j] = ps2_device_read_byte(&s_devices[i]);
+            int data = ps2_read_byte();
+            if (data == -1) {
+                break;
+            }
+            response[response_size++] = data;
+
+            dprintbyte(data);
+            dprint(" ");
         }
-        
-        if (response[0] == 0xAB && response[1] == 0x83) {
+
+        if (response_size == 2 && response[0] == 0xAB && response[1] == 0x83) {
             ps2_init_keyboard(&s_devices[i]);
+            dprintln("=> keyboard");
+        } else {
+            dprintln("=> unsupported device");
         }
     }
 
@@ -261,8 +375,6 @@ void ps2_init() {
         config |= PS2_CONFIG_INTERRUPT_SECOND;
     }
     
-    ps2_controller_send_command_with_data(PS2_COMMAND_WRITE_CONFIG, config);
-
-    ps2_update_device(&s_devices[0]);
-    ps2_update_device(&s_devices[1]);
+    TRY(ps2_controller_send_command_with_data(PS2_COMMAND_WRITE_CONFIG, config));
+    ps2_update_command_queue();
 }

--- a/src/drivers/ps2.h
+++ b/src/drivers/ps2.h
@@ -5,20 +5,12 @@
 #define PS2_TYPE_NONE		0
 #define PS2_TYPE_KEYBOARD	1
 
-#define PS2_STATE_NORMAL	0
-#define PS2_STATE_WAIT_ACK	1
-
 #define PS2_COMMAND_QUEUE_SIZE 32
 #define PS2_BYTE_BUFFER_SIZE 32
 #define PS2_EVENT_QUEUE_SIZE 32
 
 typedef struct ps2_device_t {
     u8 type;
-	u8 state;
-
-    u8 command_queue_read;
-    u8 command_queue_write;
-    u8 command_queue[PS2_COMMAND_QUEUE_SIZE];
 
 	u8 byte_buffer_len;
 	u8 byte_buffer[PS2_BYTE_BUFFER_SIZE];
@@ -34,5 +26,6 @@ typedef struct ps2_device_t {
 } ps2_device_t;
 
 void ps2_init();
-void ps2_device_append_command_queue(ps2_device_t* device, u8 byte);
+void ps2_device_append_command_queue(ps2_device_t* device, u8 command, u8 response_size);
+void ps2_device_append_command_queue_with_data(ps2_device_t* device, u8 command, u8 data, u8 response_size);
 ps2_device_t* ps2_get_device(u8 index);


### PR DESCRIPTION
PIC's default mask was incorrect, so interrupts to slave PIC would not work. I fixed the mask to be correct now.

PS/2 driver had multiple bugs, ANDing wrong flags, non synchronized commands, incorrect device detection, ...
It now be working properly. I tested the code on qemu, bochs and VirtualBox.

I also implemented super simple debug print which sends message to serial port. This is just a QOL feature for implementing more things. It was very annoying to use k_printf as it requires you to specify the line which you are printing on.

I implemented basic critical sections with macros ENTER_CRITICAL() and LEAVE_CRITICAL(). These macros allow you to easily disable interrupts for code between them without having to worry about whether interrupts were enabled or disabled outside of this block.