### PR TITLE
Peripheral Component Interconnect

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "types.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "types.h": "c"
-    }
-}

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SRCS :=						\
 	drivers/ps2.c			\
 	drivers/utils.c			\
 	drivers/vga.c			\
+	drivers/pci.c			\
 	kernel/kernel.c			\
 	kernel/krnentry.asm		\
 

--- a/src/drivers/pci.c
+++ b/src/drivers/pci.c
@@ -68,6 +68,13 @@ void debug_print_pci() {
                 dprintbyte((u8)(desc.device_id & 0xFF));
 
                 dprint("\r\n");
+
+                //an example for using the PCI information: detecting USB devices
+
+                if((desc.class_id == 0x0C) && (desc.subclass_id == 0x03)) //standard class and subclass IDs for USB devices
+                {
+                    dprintln("USB device found ^^");
+                }
             }
         }
     }

--- a/src/drivers/pci.c
+++ b/src/drivers/pci.c
@@ -1,0 +1,74 @@
+#include "pci.h"
+#include "types.h"
+#include "ports.h"
+#include "debug.h"
+
+u32 read_pci(u16 bus, u16 device, u16 function, u32 regoffset) {
+    //create ID to identify an exact function and register offset we want to start reading from (the PCI has 8 buses, 32 devices each, where each device has up to 8 functions)
+    //creating it is easy, you pretty much put the plain values there in order, so they're all shifted and ORed with each other
+    u32 id = 0x1 << 31 | ((bus & 0xFF) << 16) | ((device & 0x1F) << 11) | ((function & 0x07) << 8) | (regoffset & 0xFC);
+    port_dword_out(0xCF8, id); //give ID to PCI's command port
+    u32 result = port_dword_in(0xCFC); //read the result from PCI's data port
+    return result >> ((regoffset % 4) << 3); //the real result beginning from a register offset has to be shifted
+}
+
+void write_pci(u16 bus, u16 device, u16 function, u32 regoffset, u32 data) {
+    u32 id = 0x1 << 31 | ((bus & 0xFF) << 16) | ((device & 0x1F) << 11) | ((function & 0x07) << 8) | (regoffset & 0xFC); //we construct an ID like in the read function
+    port_dword_out(0xCF8, id); //we give the ID to PCI's command port
+    port_dword_out(0xCFC, data); //we give the data we want to send to PCI's data port
+}
+
+device_descriptor get_device_descriptor(u16 bus, u16 device, u16 function) {
+    device_descriptor result;
+
+    result.bus = bus;
+    result.device = device;
+    result.function = function;
+
+    result.vendor_id = read_pci(bus, device, function, 0x00);
+    result.device_id = read_pci(bus, device, function, 0x02);
+
+    result.class_id = read_pci(bus, device, function, 0x0b);
+    result.subclass_id = read_pci(bus, device, function, 0x0a);
+    result.interface_id = read_pci(bus, device, function, 0x09);
+
+    result.revision = read_pci(bus, device, function, 0x08);
+    result.interrupt = read_pci(bus, device, function, 0x3c);
+
+    return result;
+}
+
+void debug_print_pci() {
+    for(int bus = 0; bus < 8; bus++) //8 buses
+    {
+        for(int device = 0; device < 32; device++) //32 possible devices
+        {
+            for(int function = 0; function < 8; function++) //8 possible functionss
+            {
+                device_descriptor desc = get_device_descriptor(bus, device, function);
+
+                if(desc.vendor_id == 0x0000 || desc.vendor_id == 0xFFFF) //if the vendor ID is 0 or MAX then the function doesn't exist
+                    continue;
+
+                dprint("PCI bus: ");
+                dprintbyte((u8)(bus & 0xFF));
+
+                dprint(", Device: ");
+                dprintbyte((u8)(device & 0xFF));
+
+                dprint(", Function: ");
+                dprintbyte(((u8)((function & 0xFF))));
+
+                dprint(", Vendor ID: ");
+                dprintbyte((u8)((desc.vendor_id & 0xFF00) >> 8));
+                dprintbyte((u8)(desc.vendor_id & 0xFF));
+
+                dprint(", Device ID: ");
+                dprintbyte((u8)((desc.device_id & 0xFF00) >> 8));
+                dprintbyte((u8)(desc.device_id & 0xFF));
+
+                dprint("\r\n");
+            }
+        }
+    }
+}

--- a/src/drivers/pci.h
+++ b/src/drivers/pci.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#ifndef PCI_H
+#define PCI_H
+
+#include "types.h"
+
+u32 read_pci(u16 bus, u16 device, u16 function, u32 regoffset);
+void write_pci(u16 bus, u16 device, u16 function, u32 regoffset, u32 data);
+void debug_print_pci();
+
+typedef struct device_descriptor //to be updated eventually: there are more important values one might weant to read, like the BARs (base addresses of device buffers)
+{
+    u32 portBase;
+    u32 interrupt;
+
+    u16 bus;
+    u16 device;
+    u16 function;
+
+    u16 vendor_id;
+    u16 device_id;
+
+    u8 class_id;
+    u8 subclass_id;
+    u8 interface_id;
+
+    u8 revision;
+} device_descriptor;
+
+device_descriptor get_device_descriptor(u16 bus, u16 device, u16 function);
+
+#endif

--- a/src/drivers/ports.c
+++ b/src/drivers/ports.c
@@ -19,3 +19,13 @@ u16 port_word_in (u16 port) {
 void port_word_out (u16 port, u16 data) {
     __asm__ __volatile__("out %%ax, %%dx" : : "a" (data), "d" (port));
 }
+
+u32 port_dword_in (u16 port) {
+    u32 result;
+    asm volatile("inl %1, %0" : "=a"(result) : "Nd"(port));
+    return result;
+}
+
+void port_dword_out (u16 port, u32 data) {
+    asm volatile ("outl %0, %1" : : "a"(data), "Nd"(port));
+}

--- a/src/drivers/ports.h
+++ b/src/drivers/ports.h
@@ -3,9 +3,10 @@
 
 #include "types.h"
 
-unsigned char port_byte_in (u16 port);
+u8 port_byte_in (u16 port);
 void port_byte_out (u16 port, u8 data);
-unsigned short port_word_in (u16 port);
-void port_word_out (u16 port, u16 data);
+u16 port_word_in (u16 port);
+void port_dword_out (u16 port, u32 data);
+u32 port_dword_in (u16 port);
 
 #endif

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -13,6 +13,7 @@
 #include "../drivers/ps2_keymap_fi.h"   // <-- Finnish Keyboard Layout.
 #include "../drivers/types.h"
 #include "../drivers/vga.h"
+#include "../drivers/pci.h"
 
 /* PC Speaker Stuff */
 static void startbeep(__UINT32_TYPE__ nFrequence) {
@@ -79,6 +80,9 @@ void k_main()
 
     port_byte_out(0x3d4, 15);
     position += port_byte_in(0x3d5);
+
+    /* Print PCI devices */
+    debug_print_pci();
 
     /* Quick hack to print keyboard input */
     u16* vga_mem = (u16*)0xb8000;


### PR DESCRIPTION
I said that I'll contribute to your project as it looks very nice, and I settled on giving you some PCI code. This code allows you to communicate with the PCI (Peripheral Component Interconnect). Don't worry, the PCIe is backwards-compatible with the PCI, so it will work on newer machines too (the proper way to deal with PCIe is to get the base address for the buffer from the ACPI, ugh). This can be pretty powerful when interacting with peripherals and extension cards. As an example, I also attached a simple piece of code that can detect a USB (Universal Serial Bus) device. The commit count only reaches 99, so I haven't ruined your 100th commit, haha.