### PR TITLE
Fix missing compiler flags, implement stack smashing protector and kernel panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SRCS :=						\
 	drivers/idt.c			\
 	drivers/interrupt.asm	\
 	drivers/key.c			\
+	drivers/pci.c			\
 	drivers/pic.c			\
 	drivers/pit.c			\
 	drivers/ports.c			\
@@ -24,9 +25,9 @@ SRCS :=						\
 	drivers/ps2.c			\
 	drivers/utils.c			\
 	drivers/vga.c			\
-	drivers/pci.c			\
 	kernel/kernel.c			\
 	kernel/krnentry.asm		\
+	kernel/panic.c			\
 
 OBJS := $(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(SRCS)))
 DEPS := $(addprefix $(BUILD_DIR)/,$(addsuffix .d,$(filter-out %.asm,$(SRCS))))

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ iso: kernel
 	grub-mkrescue -o $(BUILD_DIR)/ChoacuryOS.iso $(ISO_DIR)
 
 run: iso
-	qemu-system-x86_64 -cdrom $(BUILD_DIR)/ChoacuryOS.iso -serial stdio
+	qemu-system-x86_64 -cdrom $(BUILD_DIR)/ChoacuryOS.iso -serial stdio -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
 
 clean:
 	rm -rf $(BUILD_DIR) $(ISO_DIR)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC  := gcc
 LD  := ld
 ASM := nasm
 
-CFLAGS   := -m32 -march=i386 -O2 -lto -mgeneral-regs-only -static -fPIC -fno-stack-protector -ffreestanding -Wall -Wextra
+CFLAGS   := -m32 -march=i386 -O2 -lto -mgeneral-regs-only -static -fPIC -fstack-protector -ffreestanding -Wall -Wextra
 ASMFLAGS := -f elf32
 LDFLAGS  := -m elf_i386 -T $(SRC_DIR)/linker.ld -nostdlib -flto
 
@@ -23,6 +23,7 @@ SRCS :=						\
 	drivers/ps2_keyboard.c	\
 	drivers/ps2_keymap_fi.c	\
 	drivers/ps2.c			\
+	drivers/ssp.c			\
 	drivers/utils.c			\
 	drivers/vga.c			\
 	kernel/kernel.c			\

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ CC  := gcc
 LD  := ld
 ASM := nasm
 
-CFLAGS   := -march=i386 -fno-lto -fno-stack-check -mno-sse -mno-sse2 -mno-avx -mno-mmx -static -fPIC -m32 -O3 -fno-stack-protector -ffreestanding -mno-red-zone -Wall -Wextra
+CFLAGS   := -m32 -march=i386 -O2 -lto -mgeneral-regs-only -static -fPIC -fno-stack-protector -ffreestanding -Wall -Wextra
 ASMFLAGS := -f elf32
-LDFLAGS  := -m elf_i386 -T $(SRC_DIR)/linker.ld -nostdlib
+LDFLAGS  := -m elf_i386 -T $(SRC_DIR)/linker.ld -nostdlib -flto
 
 SRCS :=						\
 	drivers/debug.c			\

--- a/src/drivers/idt.c
+++ b/src/drivers/idt.c
@@ -3,6 +3,7 @@
 #include "pic.h"
 #include "utils.h"
 #include "vga.h"
+#include "../kernel/panic.h"
 
 /* Macros for interrupt code gen */
 #define ISR_LIST_X X(0) X(1) X(2) X(3) X(4) X(5) X(6) X(7) X(8) X(9) X(10) X(11) X(12) X(13) X(14) X(15) X(16) X(17) X(18) X(19) X(20) X(21) X(22) X(23) X(24) X(25) X(26) X(27) X(28) X(29) X(30) X(31)
@@ -70,12 +71,12 @@ static const char* isr_names[] = {
     "Reserved 31"
 };
 
-void c_isr_handler(u8 isr, u32 unused) {
-    if (isr > 32)
-    {
-        // Kernel defined interrupts, non critical.
+void c_isr_handler(u8 isr, u32 error) {
+    (void)error;
 
-        return;
+    if (isr >= 32) {
+        // Kernel defined interrupts, should not be called.
+        panic("isr handler called with isr >= 32");
     }
 
     k_printf(isr_names[isr], 0, TC_LRED);

--- a/src/drivers/ssp.c
+++ b/src/drivers/ssp.c
@@ -1,0 +1,19 @@
+#include "types.h"
+#include "../kernel/panic.h"
+
+#if UINT32_MAX == UINTPTR_MAX
+#define STACK_CHK_GUARD 0x7eef2b9e
+#else
+#define STACK_CHK_GUARD 0x14047e612c70ba90
+#endif
+
+/* FIXME: This should be randomized by the bootloader.
+          As the the kernel is WIP and there are no attackers
+		  this will find bugs and is much better than nothing. */
+uptr __stack_chk_guard = STACK_CHK_GUARD;
+
+__attribute__((noreturn))
+void __stack_chk_fail(void)
+{
+	panic("Stack smashing detected");
+}

--- a/src/kernel/panic.c
+++ b/src/kernel/panic.c
@@ -1,0 +1,15 @@
+#include "panic.h"
+#include "../drivers/vga.h"
+
+__attribute__((noreturn))
+void panic_impl(const char* location_prefix, const char* message)
+{
+	k_printf(location_prefix, 0, TC_LRED);
+	k_printf(message, 1, TC_LRED);
+
+	asm volatile("cli");
+	for (;;) {
+		asm volatile("hlt");
+	}
+	__builtin_unreachable();
+}

--- a/src/kernel/panic.h
+++ b/src/kernel/panic.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define __panic_stringify_helper(s) #s
+#define __panic_stringify(s) __panic_stringify_helper(s)
+
+#define panic(message) panic_impl("kernel panic at " __FILE__ ":" __panic_stringify(__LINE__), message)
+
+__attribute__((noreturn))
+void panic_impl(const char* location_prefix, const char* message);


### PR DESCRIPTION
PC Speaker was removed in 716db407e4690c0a62555f2602ae193a1e66c0f9 so this PR adds it back.

Kernel is now compiled with -O2 instead of -O3. -O3 tends to unnecessarily increase the size of binary with optimizations that just **might** work. It is not uncommon that -O3 would make code run slower than -O2. Usually the change is only done after actual benchmarks of the performance gains and the comparison of the size of binary are considered.

Implement basic [SSP](https://wiki.osdev.org/Stack_Smashing_Protector) that should cause kernel panic on stack overflows. This will help to notice bugs regarding stack early and easily.

Implement basic kernel panic that prints source of the panic, custom message and halts the CPU. This should be used as a last resort on unrecoverable or invalid states. For example if ISR handler is called with invalid number. In that case whole IVT is probably corrupted as ISR >= 32 should be mapped to IRQ handler or not mapped at all. 