### PR TITLE
Implement terminal with scrolling support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ SRCS :=								\
 	kernel/kernel.c					\
 	kernel/krnentry.asm				\
 	kernel/panic.c					\
+	shell/terminal.c				\
 
 OBJS := $(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(SRCS)))
 DEPS := $(addprefix $(BUILD_DIR)/,$(addsuffix .d,$(filter-out %.asm,$(SRCS))))

--- a/src/drivers/idt.c
+++ b/src/drivers/idt.c
@@ -4,6 +4,7 @@
 #include "utils.h"
 #include "vga.h"
 #include "../kernel/panic.h"
+#include "../shell/terminal.h"
 
 /* Macros for interrupt code gen */
 #define ISR_LIST_X X(0) X(1) X(2) X(3) X(4) X(5) X(6) X(7) X(8) X(9) X(10) X(11) X(12) X(13) X(14) X(15) X(16) X(17) X(18) X(19) X(20) X(21) X(22) X(23) X(24) X(25) X(26) X(27) X(28) X(29) X(30) X(31)
@@ -79,7 +80,7 @@ void c_isr_handler(u8 isr, u32 error) {
         panic("isr handler called with isr >= 32");
     }
 
-    k_printf(isr_names[isr], 0, TC_LRED);
+    term_write(isr_names[isr], TC_LRED);
 
     asm volatile ("cli");
     for (;;) {
@@ -95,7 +96,7 @@ void c_irq_handler(u8 irq) {
 
     irq_handler_t handler = irq_handlers[irq];
     if (handler == 0) {
-        k_printf("no handler for irq", 0, TC_YELLO);
+        term_write("no handler for irq", TC_YELLO);
     } else {
         handler();
     }

--- a/src/drivers/vga.c
+++ b/src/drivers/vga.c
@@ -1,4 +1,5 @@
 #include "vga.h"
+#include "ports.h"
 
 /* 
 VGA Stuff, aka. (Extremely Limited) Graphics.
@@ -6,45 +7,15 @@ VGA Stuff, aka. (Extremely Limited) Graphics.
 Currently this will only work with Virtual Machines for some reason.
 */
 
-/* Function to clear off the screen */
-void k_clear_screen()
-{
-    char *vidmem = (char *) 0xb8000;
-    unsigned int i=0;
-    while(i < (80*25*2))
-    {
-        vidmem[i]=' ';
-        i++;
-        vidmem[i]=TC_WHITE;
-        i++;
-    };
-};
+void vga_set_char(u32 x, u32 y, u8 ch, u8 color) {
+    u16* base = (u16*)0xB8000;
+    base[y * VGA_WIDTH + x] = ((u16)color << 8) | ch;
+}
 
-/* A little function to print text 
-Without it, you'll just see a black screen*/
-unsigned int k_printf(const char *message, unsigned int line, unsigned int tcolour)
-{
-    char *vidmem = (char *) 0xb8000;
-    unsigned int i=0;
-
-    i=(line*80*2);
-
-    while(*message!=0)
-    {
-        if(*message=='\n')               // <-- Check for a new line
-        {
-            line++;
-            i=(line*80*2);
-            message++;
-        } else {
-            vidmem[i]=*message;
-            message++;
-            i++;
-            vidmem[i]=tcolour;          // <-- Text Colour Controller.
-                                        // E.g. if you want it lime (TC_LIME), you do k_printf("string", 0, 10) as 10 as A in hexadecimal (0x0A)
-            i++;
-        };
-    };
-
-    return 0;
-};
+void vga_move_cursor(u32 x, u32 y) {
+	u16 pos = y * VGA_WIDTH + x;
+	port_byte_out(0x3D4, 0x0F);
+	port_byte_out(0x3D5, (u8)(pos & 0xFF));
+	port_byte_out(0x3D4, 0x0E);
+	port_byte_out(0x3D5, (u8)(pos >> 8));
+}

--- a/src/drivers/vga.h
+++ b/src/drivers/vga.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "types.h"
+
 /* Colour Stuff */
 /* All of them are rendered on a black background (0x0~) */
 #define TC_BLUE 0x01
@@ -18,5 +20,8 @@
 #define TC_YELLO 0x0E
 #define TC_BRIGHT 0x0F      // <-- This makes it actually white and not light grey as used in TC_WHITE
 
-unsigned int k_printf(const char *message, unsigned int line, unsigned int tcolour);
-void k_clear_screen();
+#define VGA_WIDTH 80
+#define VGA_HEIGHT 25
+
+void vga_set_char(u32 x, u32 y, u8 ch, u8 color);
+void vga_move_cursor(u32 x, u32 y);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -14,6 +14,7 @@
 #include "../drivers/types.h"
 #include "../drivers/vga.h"
 #include "../drivers/pci.h"
+#include "../shell/terminal.h"
 
 /* PC Speaker Stuff */
 static void startbeep(__UINT32_TYPE__ nFrequence) {
@@ -50,34 +51,17 @@ void StartUp_Beeps() {
     mutebeep();
 }
 
-/* Text Cursor Updater */
-void update_cursor(int x, int y)
-{
-	__UINT16_TYPE__ pos = y * 80 + x;
- 
-	port_byte_out(0x3D4, 0x0F);
-	port_byte_out(0x3D5, (__UINT8_TYPE__) (pos & 0xFF));
-	port_byte_out(0x3D4, 0x0E);
-	port_byte_out(0x3D5, (__UINT8_TYPE__) ((pos >> 8) & 0xFF));
-}
-
 /* A Simple kernel written in C */
 void k_main() 
 {
-    /* Placeholder DEFAULT cursor vars*/
-    int prevX = 0;
-    int prevY = 4;
-
     gdt_init();
     idt_init();
 
-    update_cursor(0, 4);   // <-- Default cursor location
-
     /* Display Info Message */
-    k_clear_screen();
-    k_printf("\xB0\xB1\xB2\xDB Welcome to Choacury! \xDB\xB2\xB1\xB0", 0, 9);
-    k_printf("Version: Build " __DATE__ " (Pre-Terminal Shell)\n" 
-             "(C)opyright: \2 Pineconium 2023, 2024.", 1, 7);
+    term_init(VGA_WIDTH, VGA_HEIGHT, vga_set_char, vga_move_cursor);
+    term_write("\xB0\xB1\xB2\xDB Welcome to Choacury! \xDB\xB2\xB1\xB0\n", TC_LBLUE);
+    term_write("Version: Build " __DATE__ " (Pre-Terminal Shell)\n", TC_WHITE);
+    term_write("(C)opyright: \2 Pineconium 2023, 2024.\n\n", TC_WHITE);
 
     pic_init();     // <-- Enable clock stuff
 
@@ -91,76 +75,41 @@ void k_main()
     ps2_init_keymap_us();
 
     StartUp_Beeps();
-    
-    /* Text Cursor control */
-    // Note QEMU might cause some weird artifacts when loaded.
-    port_byte_out(0x3d4, 14);
-    int position = port_byte_in(0x3d5);
-    position = position << 8;
-
-    port_byte_out(0x3d4, 15);
-    position += port_byte_in(0x3d5);
 
     /* Print PCI devices */
     debug_print_pci();
 
-    /* Quick hack to print keyboard input */
-    u16* vga_mem = (u16*)0xb8000;
-    vga_mem += 80 * 4;
-
-    /* Allow Keyboard Entry stuff */
     for (;;) {
         key_event_t event;
         ps2_get_key_event(&event);
-        if (event.key == KEY_NONE || (event.modifiers & KEY_EVENT_MODIFIERS_RELEASED)) {
+        if (event.key == KEY_NONE) {
             asm volatile("hlt");
             continue;
         }
+        if (event.modifiers & KEY_EVENT_MODIFIERS_RELEASED) {
+            continue;
+        }
 
-        /* Backspace handler */
-        if (event.key == KEY_Backspace) {
-            if (vga_mem > (u16*)0xb8000 + 80 * 4) {      // <-- Check if the cursor isn't at spawn
-                *(--vga_mem) = (TC_WHITE << 8) | ' ';   // <-- Replaces the previous character with a blank space.
-                prevX = prevX - 1;
-                update_cursor(prevX, prevY);
-                continue;
-            }else{
-                startbeep(600);
+        switch (event.key) {
+            case KEY_Backspace:
+                term_write("\b \b", TC_WHITE);
+                break;
+            case KEY_Enter:
+                term_putchar('\n', TC_WHITE);
+                break;
+            case KEY_LeftCtrl:
+                startbeep(800);
                 pit_sleep_ms(15);
                 mutebeep();
+                break;
+            default: {
+                const char* utf8 = key_to_utf8(&event);
+                while (utf8 && *utf8) {
+                    term_putchar(*utf8, TC_WHITE);
+                    utf8++;
+                }
+                break;
             }
-        }
-
-        /* Enter Key/New Line Character */
-        if (event.key == KEY_Enter) {
-            u32 line = (vga_mem - (u16*)0xb8000) / 80;
-            vga_mem = (u16*)0xb8000 + (line + 1) * 80;  // <-- Prints a new line, but it kinda fills the remaining spaces in the line above with space characters
-                                                        // Meaning it can be annoying to edit the line above without arrow support.
-
-            /* I assume we can just put many of the terminal stuff here. */
-
-            prevY = prevY + 1;
-            prevX = 0;
-            update_cursor(prevX, prevY);
-            continue;
-        }
-
-        /* Terminal Bell */
-        if (event.key == KEY_LeftCtrl) {
-            startbeep(800);
-            pit_sleep_ms(15);
-            mutebeep();
-        }
-
-        const char* utf8 = key_to_utf8(&event);
-        if (!utf8)
-            continue;
-
-        while (*utf8) {
-            *vga_mem++ = (TC_WHITE << 8) | *utf8++;
-            prevX = prevX + 1;
-            update_cursor(prevX, prevY);
-
         }
     }
 };

--- a/src/kernel/panic.c
+++ b/src/kernel/panic.c
@@ -1,11 +1,13 @@
 #include "panic.h"
 #include "../drivers/vga.h"
+#include "../shell/terminal.h"
 
 __attribute__((noreturn))
 void panic_impl(const char* location_prefix, const char* message)
 {
-	k_printf(location_prefix, 0, TC_LRED);
-	k_printf(message, 1, TC_LRED);
+	term_write(location_prefix, TC_LRED);
+	term_putchar(' ', TC_LRED);
+	term_write(message, TC_LRED);
 
 	asm volatile("cli");
 	for (;;) {

--- a/src/shell/terminal.c
+++ b/src/shell/terminal.c
@@ -1,2 +1,160 @@
-/* Placeholder code for the Terminal/Shell */
-/* Assuming we can just move most/all terminal to KERNEL.C in the /kernel/ directory */
+#include "terminal.h"
+#include "../drivers/utils.h"
+
+// FIXME: This code should not be VGA dependant.
+//        Currently there are only colors values
+//        for VGA and no "general" ones.
+#include "../drivers/vga.h"
+
+typedef struct {
+	u8 ch;
+	u8 color;
+} term_cell_t;
+
+typedef struct {
+	u32 width;
+	u32 height;
+	set_char_t set_char;
+	move_cursor_t move_cursor;
+
+	u32 row;
+	u32 col;
+
+	// FIXME: This should be dynamically allocated
+	//        according to terminal size when memory
+	//        allocator is written.
+	term_cell_t buffer[80 * 25];
+} term_info_t;
+
+static term_info_t s_term_info;
+
+void term_init(u32 width, u32 height, set_char_t set_char, move_cursor_t move_cursor) {
+	s_term_info.width = width;
+	s_term_info.height = height;
+	s_term_info.set_char = set_char;
+	s_term_info.move_cursor = move_cursor;
+	term_clear();
+}
+
+static void term_rerender_buffer() {
+	/* loop over all cells in terminal buffer and write them to screen */
+	u32 offset = 0;
+	for (u32 y = 0; y < s_term_info.height; y++) {
+		for (u32 x = 0; x < s_term_info.width; x++) {
+			term_cell_t cell = s_term_info.buffer[offset++];
+			s_term_info.set_char(x, y, cell.ch, cell.color);
+		}
+	}
+}
+
+void term_clear() {
+	/* write all spaces to terminal buffer */
+	u32 offset = 0;
+	for (u32 y = 0; y < s_term_info.height; y++) {
+		for (u32 x = 0; x < s_term_info.width; x++) {
+			s_term_info.buffer[offset].ch = ' ';
+			s_term_info.buffer[offset].color = TC_WHITE;
+			offset++;
+		}
+	}
+
+	/* render buffer of only spaces */
+	term_rerender_buffer();
+
+	/* move cursor to top left corner */
+	s_term_info.row = 0;
+	s_term_info.col = 0;
+	s_term_info.move_cursor(s_term_info.col, s_term_info.row);
+}
+
+static void term_scroll() {
+	/* scroll all lines one up */
+	for (u32 y = 1; y < s_term_info.height; y++) {
+		term_cell_t* row1 = &s_term_info.buffer[(y - 1) * s_term_info.width];
+		term_cell_t* row2 = &s_term_info.buffer[(y - 0) * s_term_info.width];
+		memory_move((u8*)row1, (u8*)row2, s_term_info.width * sizeof(term_cell_t));
+	}
+
+	/* clear last line */
+	const u32 last_offset = (s_term_info.height - 1) * s_term_info.width;
+	for (u32 x = 0; x < s_term_info.width; x++) {
+		s_term_info.buffer[last_offset + x].ch = 0;
+	}
+
+	/* render updated buffer */
+	term_rerender_buffer();
+}
+
+void term_putchar_no_cursor_update(char ch, u8 color) {
+	switch (ch) {
+		case '\b':
+			// move cursor one cell back
+			if (s_term_info.col > 0) {
+				s_term_info.col--;
+			}
+			break;
+		case '\n':
+			// move cursor too next line
+			s_term_info.col = 0;
+			s_term_info.row++;
+			break;
+		default: {
+			// put character into buffer
+			u32 offset = s_term_info.row * s_term_info.width + s_term_info.col;
+			term_cell_t* cell = &s_term_info.buffer[offset];
+			cell->ch = ch;
+			cell->color = color;
+
+			// render new character to screen
+			s_term_info.set_char(s_term_info.col, s_term_info.row, ch, color);
+
+			// move cursor one right
+			s_term_info.col++;
+			break;
+		}
+	}
+
+	/* handle cursor overflow from right */
+	if (s_term_info.col >= s_term_info.width) {
+		s_term_info.col = 0;
+		s_term_info.row++;
+	}
+
+	/* handle terminal scrolling */
+	if (s_term_info.row >= s_term_info.height) {
+		term_scroll();
+		s_term_info.row = s_term_info.height - 1;
+	}
+}
+
+void term_putchar(char ch, u8 color) {
+	term_putchar_no_cursor_update(ch, color);
+
+	/* update shown cursor position */
+	s_term_info.move_cursor(s_term_info.col, s_term_info.row);
+}
+
+void term_set_cursor(u32 x, u32 y) {
+	/* update cursor column and clamp to terminal width */
+	s_term_info.col = x;
+	if (s_term_info.col >= s_term_info.width)
+		s_term_info.col = s_term_info.width - 1;
+
+	/* update cursor row and clamp to terminal height */
+	s_term_info.row = y;
+	if (s_term_info.row >= s_term_info.height)
+		s_term_info.row = s_term_info.height - 1;
+
+	/* update shown cursor position */
+	s_term_info.move_cursor(s_term_info.col, s_term_info.row);
+}
+
+void term_write(const char* message, u8 color) {
+	while (*message) {
+		term_putchar_no_cursor_update(*message, color);
+		message++;
+	}
+
+	/* update shown cursor position */
+	s_term_info.move_cursor(s_term_info.col, s_term_info.row);
+}

--- a/src/shell/terminal.h
+++ b/src/shell/terminal.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../drivers/types.h"
+
+typedef void (*set_char_t)(u32, u32, u8, u8);
+typedef void (*move_cursor_t)(u32, u32);
+
+void term_init(u32 width, u32 height, set_char_t set_char, move_cursor_t move_cursor);
+void term_clear();
+void term_putchar(char ch, u8 color);
+void term_set_cursor(u32 x, u32 y);
+void term_write(const char* message, u8 color);


### PR DESCRIPTION
This PR replaces old VGA specific printf with more generalized terminal API (with scrolling support).

You no longer specify the line where you want to print, and instead the terminal keeps track of the current cursor position. If you want to write to specific place, you have to call term_move_cursor() after which the following calls to term_putchar() and term_write() print to the new location.

I reworked the current keyboard echoing to use this new terminal API and removed the old k_clear_screen() and k_printf().

If there is anything you want to be different or don't agree with, please leave a comment. If @Pineconium would like to write terminal scrolling by himself, this PR can stand as a guide.