### PR TITLE
Fix command length check and print order

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -113,10 +113,10 @@ void shell_start() {
             default: {
                 const char* utf8 = key_to_utf8(&event);
                 while (utf8 && *utf8) {
-                    term_putchar(*utf8, TC_WHITE);
                     if (command_length >= sizeof(command_buffer) - 1) {
                         break;
                     }
+                    term_putchar(*utf8, TC_WHITE);
                     command_buffer[command_length] = *utf8;
                     command_length++;
                     utf8++;


### PR DESCRIPTION
I accidentally had these 2 lines in the wrong order. This allowed shell to display infinite length command while buffer only keeps first 256 bytes