### PR TITLE
Implement basic ATA driver for reading from disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ SRCS :=								\
 	drivers/keymaps/ps2_keymap_us.c	\
 	drivers/ps2.c					\
 	drivers/sound.c					\
+	drivers/storage/ata.c			\
+	drivers/storage/device.c		\
 	drivers/ssp.c					\
 	drivers/utils.c					\
 	drivers/vga.c					\
@@ -52,7 +54,7 @@ iso: kernel
 	grub-mkrescue -o $(BUILD_DIR)/ChoacuryOS.iso $(ISO_DIR)
 
 run: iso
-	qemu-system-x86_64 -cdrom $(BUILD_DIR)/ChoacuryOS.iso -serial stdio -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
+	qemu-system-x86_64 -hda $(BUILD_DIR)/ChoacuryOS.iso -serial stdio -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
 
 clean:
 	rm -rf $(BUILD_DIR) $(ISO_DIR)

--- a/src/drivers/debug.c
+++ b/src/drivers/debug.c
@@ -1,10 +1,15 @@
 #include "debug.h"
 #include "ports.h"
 
+void dprintchar(char c)
+{
+    port_byte_out(0x3F8, c);
+}
+
 void dprint(const char* message)
 {
     for (int i = 0; message[i]; i++) {
-        port_byte_out(0x3F8, message[i]);
+        dprintchar(message[i]);
     }
 }
 
@@ -15,9 +20,29 @@ void dprintln(const char* message)
 }
 
 void dprintbyte(u8 byte) {
-    char buffer[3];
-    buffer[0] = ((byte >>   4) < 10) ? (byte >>   4) + '0' : (byte >>   4) - 10 + 'a';
-    buffer[1] = ((byte & 0x0F) < 10) ? (byte & 0x0F) + '0' : (byte & 0x0F) - 10 + 'a';
-    buffer[2] = '\0';
-    dprint(buffer);
+    dprintchar(((byte >>   4) < 10) ? (byte >>   4) + '0' : (byte >>   4) - 10 + 'a');
+    dprintchar(((byte & 0x0F) < 10) ? (byte & 0x0F) + '0' : (byte & 0x0F) - 10 + 'a');
+}
+
+void dprintint(s64 value) {
+    if (value < 0) {
+        dprint("-");
+        value = -value;
+    }
+
+    if (value == 0) {
+        dprint("0");
+        return;
+    }
+
+    char buffer[21];
+    int len = 0;
+    while (value > 0) {
+        buffer[len++] = (value % 10) + '0';
+        value /= 10;
+    }
+
+    for (int i = len - 1; i >= 0; i--) {
+        dprintchar(buffer[i]);
+    }
 }

--- a/src/drivers/debug.h
+++ b/src/drivers/debug.h
@@ -2,6 +2,8 @@
 
 #include "types.h"
 
+void dprintchar(char c);
 void dprint(const char* message);
 void dprintln(const char* message);
 void dprintbyte(u8);
+void dprintint(s64);

--- a/src/drivers/ssp.c
+++ b/src/drivers/ssp.c
@@ -17,3 +17,9 @@ void __stack_chk_fail(void)
 {
 	panic("Stack smashing detected");
 }
+
+__attribute__((noreturn))
+void __stack_chk_fail_local(void)
+{
+	__stack_chk_fail();
+}

--- a/src/drivers/storage/ata.c
+++ b/src/drivers/storage/ata.c
@@ -1,0 +1,222 @@
+#include "../debug.h"
+#include "../ports.h"
+#include "ata.h"
+#include "device.h"
+
+#define ATA_IO_REG_DATA 0
+#define ATA_IO_REG_ERROR 1
+#define ATA_IO_REG_FEATURES 1
+#define ATA_IO_REG_SECTOR_COUNT 2
+#define ATA_IO_REG_LBA0 3
+#define ATA_IO_REG_LBA1 4
+#define ATA_IO_REG_LBA2 5
+#define ATA_IO_REG_DEVICE_SELECT 6
+#define ATA_IO_REG_COMMAND 7
+#define ATA_IO_REG_STATUS 7
+
+#define ATA_CTRL_REG_ALT_STATUS 0
+#define ATA_CTRL_REG_DEVICE_CONTROL 0
+#define ATA_CTRL_REG_DRIVE_ADDRESS 1
+
+#define ATA_STATUS_ERR (1 << 0)
+#define ATA_STATUS_IDX (1 << 1)
+#define ATA_STATUS_CORR (1 << 4)
+#define ATA_STATUS_DRQ (1 << 3)
+#define ATA_STATUS_SRV (1 << 4)
+#define ATA_STATUS_DF (1 << 5)
+#define ATA_STATUS_RDY (1 << 6)
+#define ATA_STATUS_BSY (1 << 7)
+
+typedef struct {
+    storage_device_t device;
+    u16 io_base;
+    u16 control_base;
+    u8 index;
+} ata_device_t;
+
+// FIXME: this should be dynamic
+static ata_device_t g_ata_devices[4];
+static int g_ata_device_count = 0;
+
+// 400 ns delay
+static void ata_select_delay(u16 control_base) {
+    for (int i = 0; i < 4; i++) {
+        port_byte_in(control_base + ATA_CTRL_REG_ALT_STATUS);
+    }
+}
+
+static bool ata_read_sectors(void* self, void* buffer, u64 sector, u64 count) {
+    if (sector + count > (1 << 28)) {
+        dprintln("ATA read: only 28-bit LBA is supported");
+        return false;
+    }
+    if (count > 0xFF) {
+        dprintln("ATA read: only 8-bit sector count is supported");
+        return false;
+    }
+
+    ata_device_t* device = (ata_device_t*)self;
+
+    if (sector + count > device->device.sector_count) {
+        dprintln("ATA read: sector out of range");
+        return false;
+    }
+
+    // select device
+    port_byte_out(device->io_base + ATA_IO_REG_DEVICE_SELECT, 0xE0 | (device->index << 4) | ((sector >> 24) & 0x0F));
+    ata_select_delay(device->control_base);
+
+    // send read command
+    port_byte_out(device->io_base + ATA_IO_REG_SECTOR_COUNT, count);
+    port_byte_out(device->io_base + ATA_IO_REG_LBA0, sector >>  0);
+    port_byte_out(device->io_base + ATA_IO_REG_LBA1, sector >>  8);
+    port_byte_out(device->io_base + ATA_IO_REG_LBA2, sector >> 16);
+    port_byte_out(device->io_base + ATA_IO_REG_COMMAND, 0x20);
+
+    for (u64 i = 0; i < count; i++) {
+        // wait for BSY to clear
+        u8 status = port_byte_in(device->io_base + ATA_IO_REG_STATUS);
+        while (status & ATA_STATUS_BSY) {
+            status = port_byte_in(device->io_base + ATA_IO_REG_STATUS);
+        }
+
+        // wait for DRQ or ERR
+        while (!(status & (ATA_STATUS_DRQ | ATA_STATUS_ERR))) {
+            status = port_byte_in(device->io_base + ATA_IO_REG_STATUS);
+        }
+
+        // check for error
+        if (status & ATA_STATUS_ERR) {
+            dprintln("ATA read: error");
+            return false;
+        }
+
+        // read data
+        const u32 words_per_sector = device->device.sector_size / 2;
+        for (u32 j = 0; j < words_per_sector; j++) {
+            ((u16*)buffer)[i * words_per_sector + j] = port_word_in(device->io_base + ATA_IO_REG_DATA);
+        }
+    }
+
+    return true;
+}
+
+static bool ata_write_sectors(void* self, const void* buffer, u64 sector, u64 count) {
+    (void)self;
+    (void)buffer;
+    (void)sector;
+    (void)count;
+    dprintln("ATA write not implemented");
+    return false;
+}
+
+static void ata_bus_init(u16 io_base, u16 control_base) {
+    // check if there is no bus connected
+    if (port_byte_in(io_base + ATA_IO_REG_STATUS) == 0xFF) {
+        return;
+    }
+
+    for (int i = 0; i < 2; i++) {
+        // select device
+        port_byte_out(io_base + ATA_IO_REG_DEVICE_SELECT, 0xA0 | (i << 4));
+        ata_select_delay(control_base);
+
+        // send ATA identify command
+        port_byte_out(io_base + ATA_IO_REG_LBA0, 0);
+        port_byte_out(io_base + ATA_IO_REG_LBA1, 0);
+        port_byte_out(io_base + ATA_IO_REG_LBA2, 0);
+        port_byte_out(io_base + ATA_IO_REG_COMMAND, 0xEC);
+
+        // check if device is present
+        u8 status = port_byte_in(io_base + ATA_IO_REG_STATUS);
+        if (status == 0) {
+            continue;
+        }
+
+        // wait for BSY to clear
+        while (status & ATA_STATUS_BSY) {
+            status = port_byte_in(io_base + ATA_IO_REG_STATUS);
+        }
+
+        // check LBA1 and LBA2 to see if the device is not ATA
+        if (port_byte_in(io_base + ATA_IO_REG_LBA1) != 0 || port_byte_in(io_base + ATA_IO_REG_LBA2) != 0) {
+            continue;
+        }
+
+        // wait for DRQ or ERR
+        while (!(status & (ATA_STATUS_DRQ | ATA_STATUS_ERR))) {
+            status = port_byte_in(io_base + ATA_IO_REG_STATUS);
+        }
+
+        // check for error
+        if (status & ATA_STATUS_ERR) {
+            dprint("ATA device on bus 0x");
+            dprintbyte(io_base >> 8);
+            dprintbyte(io_base & 0xFF);
+            dprint(" device ");
+            dprintint(i);
+            dprintln(" returned error");
+            continue;
+        }
+
+        // read device info
+        u16 data[256];
+        for (int i = 0; i < 256; i++) {
+            data[i] = port_word_in(io_base + ATA_IO_REG_DATA);
+        }
+
+        // get sector count
+        u64 sector_count = 0;
+        if (data[83] & (1 << 10)) {
+            sector_count = data[100] | (data[101] << 16) | ((u64)data[102] << 32) | ((u64)data[103] << 48);
+        } else {
+            sector_count = data[60] | (data[61] << 16);
+        }
+
+        // get sector size
+        u32 sector_size = 512;
+        if (((data[106] >> 12) & 0b1101) == 0b1000) {
+            sector_size = data[117] | (data[118] << 16);
+        }
+
+        // read device model
+        char model[41];
+        for (int i = 0; i < 20; i++) {
+            model[2 * i + 0] = data[27 + i] >> 8;
+            model[2 * i + 1] = data[27 + i] & 0xFF;
+        }
+        for (int i = 39; i >= 0; i--) {
+            if (model[i] != ' ') {
+                break;
+            }
+            model[i] = 0;
+        }
+        model[40] = 0;
+
+        dprint("Found ATA device '");
+        dprint(model);
+        dprint("' (");
+        dprintint(sector_count * sector_size / 1024 / 1024);
+        dprintln(" MB)");
+
+        g_ata_devices[g_ata_device_count].device.read_sectors = ata_read_sectors;
+        g_ata_devices[g_ata_device_count].device.write_sectors = ata_write_sectors;
+        g_ata_devices[g_ata_device_count].device.sector_count = sector_count;
+        g_ata_devices[g_ata_device_count].device.sector_size = sector_size;
+        g_ata_devices[g_ata_device_count].io_base = io_base;
+        g_ata_devices[g_ata_device_count].control_base = control_base;
+        g_ata_devices[g_ata_device_count].index = i;
+        g_ata_device_count++;
+    }
+}
+
+void ata_controller_init() {
+    // FIXME: this should be done through PCI
+    ata_bus_init(0x1F0, 0x3F6);
+    ata_bus_init(0x170, 0x376);
+
+    // add all found devices to the list of storage devices
+    for (int i = 0; i < g_ata_device_count; i++) {
+        g_storage_devices[g_storage_device_count++] = (storage_device_t*)&g_ata_devices[i];
+    }
+}

--- a/src/drivers/storage/ata.h
+++ b/src/drivers/storage/ata.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void ata_controller_init();

--- a/src/drivers/storage/device.c
+++ b/src/drivers/storage/device.c
@@ -1,0 +1,17 @@
+#include "ata.h"
+#include "device.h"
+#include <stddef.h>
+
+int g_storage_device_count ;
+storage_device_t* g_storage_devices[MAX_STORAGE_DEVICES];
+
+int storage_device_init() {
+    g_storage_device_count = 0;
+    for (int i = 0; i < MAX_STORAGE_DEVICES; i++) {
+        g_storage_devices[i] = NULL;
+    }
+
+    ata_controller_init();
+
+    return g_storage_device_count;
+}

--- a/src/drivers/storage/device.h
+++ b/src/drivers/storage/device.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../types.h"
+#include <stdbool.h>
+
+#define MAX_STORAGE_DEVICES 16
+
+typedef struct {
+    bool (*read_sectors)(void* self, void* buffer, u64 sector, u64 count);
+    bool (*write_sectors)(void* self, const void* buffer, u64 sector, u64 count);
+    u64 sector_count;
+    u32 sector_size;
+} storage_device_t;
+
+// Initialize all storage devices
+// Returns the number of storage devices found
+int storage_device_init();
+
+extern int g_storage_device_count;
+extern storage_device_t* g_storage_devices[MAX_STORAGE_DEVICES];

--- a/src/drivers/utils.c
+++ b/src/drivers/utils.c
@@ -36,22 +36,31 @@ void iota(int n, char str[]) {
     str[i] = '\0';
 }
 
-// String to interger (for positive numbers)
-int atoi_pos(const char* str) {
-    int result = 0;
-    while (*str) {
-        if (*str < '0' || *str > '9') {
-            return -1;
-        }
-        result = (result * 10) + (*str - '0');
-        str++;
-    }
-    return result;
+atoi_result_t atoi(const char* str) {
+	// parse optional sign
+	bool negative = (*str == '-');
+	if (*str == '-' || *str == '+') {
+		str++;
+	}
+
+	// parse digits
+	int value = 0;
+	while (*str) {
+		if (*str < '0' || *str > '9') {
+			atoi_result_t result = { .valid = false, .value = 0 };
+			return result;
+		}
+		value = (value * 10) + (*str - '0');
+		str++;
+	}
+
+	if (negative) {
+		value = -value;
+	}
+
+	atoi_result_t result = { .valid = true, .value = value };
+	return result;
 }
-
-// String to interger (for negative numbers)
-// TODO: Copy ATOI_POS's code and modifiy it for negative numbers
-
 
 int strlen(const char *str) {
 	int i = 0;

--- a/src/drivers/utils.h
+++ b/src/drivers/utils.h
@@ -1,12 +1,17 @@
 #pragma once
 
 #include "types.h"
+#include <stdbool.h>
 
 void memory_copy(u8 *dest, const u8 *source, u32 nbytes);
 void memory_move(u8 *dest, const u8 *source, u32 nbytes);
 void memory_set(u8 *dest, u8 val, u32 len);
-void int_to_ascii(int n, char str[]);
-void ascii_to_int(char str[]);
+
+typedef struct {
+	bool valid;
+	int value;
+} atoi_result_t;
+atoi_result_t atoi(const char*);
 
 int strlen(const char *str);
 int strcmp(const char *str1, const char *str2);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -12,6 +12,7 @@
 #include "../drivers/ps2.h"
 #include "../drivers/keymaps/ps2_keymap_us.h"   // <-- US Keyboard Layout.
 #include "../drivers/sound.h"
+#include "../drivers/storage/device.h"
 #include "../drivers/types.h"
 #include "../drivers/vga.h"
 #include "../drivers/pci.h"
@@ -52,6 +53,9 @@ void k_main()
     ps2_init_keymap_us();
 
     StartUp_Beeps();
+
+    /* Initialize storage devices */
+    storage_device_init();
 
     /* Print PCI devices */
     debug_print_pci();

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -33,33 +33,29 @@ static void handle_command(int argc, const char** argv) {
     }
     else if (strcmp(argv[0], "beep") == 0) {
         if (argc >= 4) {
-            term_write("ERROR 3: Too much arguments.", TC_LRED);
+            term_write("ERROR 3: Too many arguments.", TC_LRED);
             term_write("\n", TC_LRED);
         }
         else {
-            if (atoi_pos(argv[1]) == -1) {
-                term_write("ERROR 2: Arg1 is not an interger\n", TC_LRED);
-            }
-            else {
-                if (atoi_pos(argv[2]) == -1) {
-                    int beeplength = 500; // <-- Default beep length (500ms)
-                    startbeep(atoi_pos(argv[1]));
-                    pit_sleep_ms(beeplength);
-                    mutebeep();
-                }
-                else if (argc == 2) {
-                    int beeplength = 500; // <-- Default beep length (500ms)
-                    startbeep(atoi_pos(argv[1]));
-                    pit_sleep_ms(beeplength);
-                    mutebeep();
-                }
-                else {
-                    int beeplength = atoi_pos(argv[2]);
-                    startbeep(atoi_pos(argv[1]));
-                    pit_sleep_ms(beeplength);
-                    mutebeep();
-                }
-            }
+			atoi_result_t frequency = atoi(argv[1]);
+			if (!frequency.valid) {
+				term_write("ERROR 2: Arg1 is not an interger\n", TC_LRED);
+				return;
+			}
+
+			// default beep length (500 ms)
+			atoi_result_t duration = { .valid = true, .value = 500 };
+			if (argc >= 3) {
+				duration = atoi(argv[2]);
+			}
+			if (!duration.valid) {
+				term_write("ERROR 2: Arg2 is not an interger\n", TC_LRED);
+				return;
+			}
+
+			startbeep(frequency.value);
+			pit_sleep_ms(duration.value);
+			mutebeep();
         }
     }
     else if (strcmp(argv[0], "cls") == 0) {

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -28,35 +28,38 @@ static void handle_command(int argc, const char** argv) {
         term_write("echo (string)       - Prints string to the console\n", TC_WHITE);   // <-- Work in progress.
     }
     else if (strcmp(argv[0], "echo") == 0) {
-        term_write(argv[1], TC_WHITE);  // <-- Prints the first word (will be fixed!)
+        for (int i = 1; i < argc; i++) {
+            if (i > 1)
+                term_write(" ", TC_WHITE);
+            term_write(argv[i], TC_WHITE);
+        }
         term_write("\n", TC_WHITE);
     }
     else if (strcmp(argv[0], "beep") == 0) {
-        if (argc >= 4) {
-            term_write("ERROR 3: Too many arguments.", TC_LRED);
-            term_write("\n", TC_LRED);
+        if (argc != 2 && argc != 3) {
+            term_write("ERROR: Usage: beep frequency [duration]\n", TC_LRED);
+            return;
         }
-        else {
-			atoi_result_t frequency = atoi(argv[1]);
-			if (!frequency.valid) {
-				term_write("ERROR 2: Arg1 is not an interger\n", TC_LRED);
-				return;
-			}
 
-			// default beep length (500 ms)
-			atoi_result_t duration = { .valid = true, .value = 500 };
-			if (argc >= 3) {
-				duration = atoi(argv[2]);
-			}
-			if (!duration.valid) {
-				term_write("ERROR 2: Arg2 is not an interger\n", TC_LRED);
-				return;
-			}
-
-			startbeep(frequency.value);
-			pit_sleep_ms(duration.value);
-			mutebeep();
+        atoi_result_t frequency = atoi(argv[1]);
+        if (!frequency.valid) {
+            term_write("ERROR: Frequency is not an interger\n", TC_LRED);
+            return;
         }
+
+        // default beep length (500 ms)
+        atoi_result_t duration = { .valid = true, .value = 500 };
+        if (argc >= 3) {
+            duration = atoi(argv[2]);
+        }
+        if (!duration.valid) {
+            term_write("ERROR: Duration is not an interger\n", TC_LRED);
+            return;
+        }
+
+        startbeep(frequency.value);
+        pit_sleep_ms(duration.value);
+        mutebeep();
     }
     else if (strcmp(argv[0], "cls") == 0) {
         term_clear();
@@ -65,7 +68,7 @@ static void handle_command(int argc, const char** argv) {
         term_write(__DATE__ "\n", TC_WHITE);
     }
     else {
-        term_write("ERROR 1: Unknown command: ", TC_YELLO);
+        term_write("ERROR: Unknown command: ", TC_YELLO);
         term_write(argv[0], TC_YELLO);
         term_write("\n", TC_YELLO);
     }


### PR DESCRIPTION
This PR implements simple ATA driver that can read from disk with polling.

src/drivers/storage/device.h contains an integer (g_storage_device_count) containing the number of initialized storage devices and an array of storage device pointers (g_storage_devices).

For example if g_storage_device_count is 2, both g_storage_devices[0] and g_storage_devices[1] contain valid storage devices.

Storage device contains its size (number of sectors and size of a single sector) and callbacks for reading and writing. These callbacks take pointer to the device, buffer, sector index and number of sectors as arguments. Callbacks return true on success and false on error.

I tried to write storage device as a generic structure that can be used for all different drives in the future.

For example to read 2 sectors starting at index 4 from the first storage device, you can do the following:
```C
u8 buffer[1024]; // needs to be at least sector_size * sector_count bytes
storage_device_t* device = g_storage_devices[0];
if (device->read_sectors(device, buffer, 4, 2)) {
    term_write("read success\n");
    // now buffer holds the read data
} else {
    term_write("read failed\n");
}
```