### PR TITLE
Implement basic GPT partition probing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ SRCS :=								\
 	drivers/sound.c					\
 	drivers/storage/ata.c			\
 	drivers/storage/device.c		\
+	drivers/storage/gpt.c			\
+	drivers/storage/partition.c		\
 	drivers/ssp.c					\
 	drivers/utils.c					\
 	drivers/vga.c					\

--- a/src/drivers/storage/device.c
+++ b/src/drivers/storage/device.c
@@ -1,5 +1,6 @@
 #include "ata.h"
 #include "device.h"
+#include "partition.h"
 #include <stddef.h>
 
 int g_storage_device_count ;
@@ -12,6 +13,10 @@ int storage_device_init() {
     }
 
     ata_controller_init();
+
+	for (int i = 0; i < g_storage_device_count; i++) {
+		partition_probe(g_storage_devices[i]);
+	}
 
     return g_storage_device_count;
 }

--- a/src/drivers/storage/gpt.c
+++ b/src/drivers/storage/gpt.c
@@ -1,0 +1,85 @@
+#include "../debug.h"
+#include "../utils.h"
+#include "gpt.h"
+
+struct gpt_header {
+	u8 signature[8];
+	u32 revision;
+	u32 header_size;
+	u32 header_crc32;
+	u32 reserved;
+	u64 current_lba;
+	u64 backup_lba;
+	u64 first_usable_lba;
+	u64 last_usable_lba;
+	u8 disk_guid[16];
+	u64 partition_entry_lba;
+	u32 num_partition_entries;
+	u32 size_partition_entry;
+	u32 partition_entry_array_crc32;
+} __attribute__((packed));
+
+struct gpt_partition_entry {
+	u8 partition_type_guid[16];
+	u8 unique_partition_guid[16];
+	u64 first_lba;
+	u64 last_lba;
+	u64 attributes;
+	u16 partition_name[36];
+} __attribute__((packed));
+
+bool partition_probe_gpt(storage_device_t* device, u8 buffer[512]) {
+	struct gpt_header* gpt_header = (struct gpt_header*)buffer;
+	if (memcmp(gpt_header->signature, "EFI PART", 8) != 0) {
+		return false;
+	}
+
+	dprint("Found GPT on '");
+	dprint(device->model);
+	dprintln("'");
+
+	// FIXME: Do error checking
+	
+	u8 partition_buffer[512];
+	u32 last_partition_lba = 0;
+
+	for (u32 i = 0; i < gpt_header->num_partition_entries; i++) {
+		u32 byte_offset = gpt_header->partition_entry_lba * device->sector_size + i * gpt_header->size_partition_entry;
+		if (byte_offset / device->sector_size != last_partition_lba) {
+			if (!device->read_sectors(device, partition_buffer, byte_offset / device->sector_size, 1)) {
+				dprint("\e[33mFailed to read partition entry ");
+				dprintint(i);
+				dprintln("\e[m");
+				return false;
+			}
+			last_partition_lba = byte_offset / device->sector_size;
+		}
+
+		struct gpt_partition_entry* gpt_partition_entry = (struct gpt_partition_entry*)(partition_buffer + byte_offset % device->sector_size);
+		u8 zero_guid[16] = { 0 };
+		if (memcmp(gpt_partition_entry->partition_type_guid, zero_guid, 16) == 0) {
+			continue;
+		}
+
+		u64 sectors = gpt_partition_entry->last_lba - gpt_partition_entry->first_lba + 1;
+		u64 size = sectors * device->sector_size;
+
+		dprint("  partition ");
+		dprintint(i);
+		dprintln(":");
+	
+		dprint("    size: ");
+		dprintint(size / 1024 / 1024);
+		dprintln(" MiB");
+	
+		dprint("    name: '");
+		for (int j = 0; j < 36; j++) {
+			dprintchar(gpt_partition_entry->partition_name[j]);
+		}
+		dprintln("'");
+
+		// FIXME: Create partition device when we have dynamic memory allocation
+	}
+
+	return true;
+}

--- a/src/drivers/storage/gpt.h
+++ b/src/drivers/storage/gpt.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "device.h"
+
+bool partition_probe_gpt(storage_device_t*, u8 buffer[512]);

--- a/src/drivers/storage/partition.c
+++ b/src/drivers/storage/partition.c
@@ -1,0 +1,26 @@
+#include "../debug.h"
+#include "../utils.h"
+#include "gpt.h"
+#include "partition.h"
+
+bool partition_probe(storage_device_t* device) {
+	u8 buffer[512];
+
+	// Read the first sector of the device
+	if (!device->read_sectors(device, buffer, 1, 1)) {
+		dprint("\e[33mFailed to read sector 1 of '");
+		dprint(device->model);
+		dprintln("'\e[m");
+		return false;
+	}
+
+	if (memcmp(buffer, "EFI PART", 8) == 0) {
+		return partition_probe_gpt(device, buffer);
+	}
+
+	dprint("\e[33mNo known partition table found on '");
+	dprint(device->model);
+	dprintln("'\e[m");
+
+	return false;
+}

--- a/src/drivers/storage/partition.h
+++ b/src/drivers/storage/partition.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "device.h"
+
+bool partition_probe(storage_device_t*);

--- a/src/drivers/utils.c
+++ b/src/drivers/utils.c
@@ -24,6 +24,17 @@ void memory_set(u8 *dest, u8 val, u32 len) {
     }
 }
 
+int memcmp(const void *a, const void *b, u32 len) {
+	const u8* a_u8 = (const u8*)a;
+	const u8* b_u8 = (const u8*)b;
+	for (u32 i = 0; i < len; i++) {
+		if (a_u8[i] != b_u8[i]) {
+			return (int)a_u8[i] - (int)b_u8[i];
+		}
+	}
+	return 0;
+}
+
 void iota(int n, char str[]) {
     int i, sign;
     if ((sign = n) < 0) n = -n;

--- a/src/drivers/utils.h
+++ b/src/drivers/utils.h
@@ -6,6 +6,7 @@
 void memory_copy(u8 *dest, const u8 *source, u32 nbytes);
 void memory_move(u8 *dest, const u8 *source, u32 nbytes);
 void memory_set(u8 *dest, u8 val, u32 len);
+int memcmp(const void *a, const void *b, u32 len);
 
 typedef struct {
 	bool valid;


### PR DESCRIPTION
This PR adds simple GPT partition probing which just prints partition entries to the debug console.

Partitions are not collected anywhere as it would be too ugly without dynamic memory allocator. This should be the next big feature added. Most of the current code over the whole code base is really hacky with static memory.