### PR TITLE
Implement a FAT12/16/32 driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 BUILD_DIR := build
 SRC_DIR   := src
-ISO_DIR   := isodir
 
 CC  := gcc
 LD  := ld
@@ -50,17 +49,14 @@ kernel: $(OBJS)
 	$(LD) $(LDFLAGS) $(OBJS) -o $(BUILD_DIR)/ChoacuryOS.bin
 	grub-file --is-x86-multiboot $(BUILD_DIR)/ChoacuryOS.bin	
 
-iso: kernel
-	@mkdir -p $(ISO_DIR)/boot/grub
-	cp $(BUILD_DIR)/ChoacuryOS.bin $(ISO_DIR)/boot/ChoacuryOS.bin
-	cp $(SRC_DIR)/boot/grub.cfg $(ISO_DIR)/boot/grub/grub.cfg
-	grub-mkrescue -o $(BUILD_DIR)/ChoacuryOS.iso $(ISO_DIR)
+img: kernel
+	./create-disk.sh
 
-run: iso
-	qemu-system-x86_64 -hda $(BUILD_DIR)/ChoacuryOS.iso -serial stdio -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
+run: img
+	qemu-system-x86_64 -hda $(BUILD_DIR)/ChoacuryOS.img -serial stdio -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0
 
 clean:
-	rm -rf $(BUILD_DIR) $(ISO_DIR)
+	rm -rf $(BUILD_DIR)
 
 -include $(DEPS)
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LDFLAGS  := -m elf_i386 -T $(SRC_DIR)/linker.ld -nostdlib -flto
 
 SRCS :=								\
 	drivers/debug.c					\
+	drivers/filesystem/fat.c		\
 	drivers/gdt.c					\
 	drivers/idt.c					\
 	drivers/interrupt.asm			\

--- a/create-disk.sh
+++ b/create-disk.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+MOUNT_DIR=build/mount
+DISK_PATH=build/ChoacuryOS.img
+DISK_SIZE=$((50 * 1024 * 1024))
+
+test -f $DISK_PATH
+SHOULD_BUILD=$?
+
+if (($SHOULD_BUILD)); then
+	# create empty disk image
+	truncate -s 0 $DISK_PATH
+	dd if=/dev/zero of=$DISK_PATH bs=512 count=$(($DISK_SIZE / 512))
+
+	# create partition table
+	parted --script $DISK_PATH	 \
+		mklabel gpt              \
+		mkpart boot 1M 2M        \
+		set 1 bios_grub on       \
+		mkpart root ext2 2M 100%
+fi
+
+# create loop device
+LOOP_DEV=$(sudo losetup --show  -fP $DISK_PATH || exit 1)
+PARTITION1=${LOOP_DEV}p1
+PARTITION2=${LOOP_DEV}p2
+if [ ! -b $PARTITION1 ] || [ ! -b $PARTITION2 ]; then
+	echo "Failed to probe partitions for disk image." >&2
+	sudo losetup -d $LOOP_DEV
+	exit 1
+fi
+
+if (($SHOULD_BUILD)); then
+	# create root filesystem
+	sudo mkfs.fat $PARTITION2
+fi
+
+# mount root filesystem
+mkdir -p $MOUNT_DIR
+sudo mount $PARTITION2 "$MOUNT_DIR"
+
+if (($SHOULD_BUILD)); then
+	# install grub
+	sudo grub-install						\
+		--no-floppy							\
+		--target=i386-pc					\
+		--modules="normal ext2 multiboot"	\
+		--boot-directory="$MOUNT_DIR/boot"	\
+		$LOOP_DEV
+
+	sudo mkdir -p "$MOUNT_DIR/boot/grub"
+	sudo cp src/boot/grub.cfg $MOUNT_DIR/boot/grub/
+fi
+
+# copy kernel to boot
+sudo cp build/ChoacuryOS.bin $MOUNT_DIR/boot/
+
+# cleanup
+sudo umount "$MOUNT_DIR"
+sudo losetup -d $LOOP_DEV

--- a/src/drivers/filesystem/fat.c
+++ b/src/drivers/filesystem/fat.c
@@ -1,38 +1,18 @@
 // FAT support
 
 #include "fat.h"
+#include "../debug.h"
 #include "../types.h"
-
-// Global variables
-unsigned int fat_type;
-unsigned int first_fat_sector;
-unsigned int first_data_sector;
-unsigned int total_clusters;
-
-// This actually makes the fat stuff work.
-void FAT_Init(){
-    return 0; // <-- THIS IS JUST A PLACEHOLDER!
-}
-
-// Open a file
-void FAT_Open(file){
-    return 0; // <-- THIS IS JUST A PLACEHOLDER!
-}
-
-// Reads a file
-void FAT_Read(file){
-    return 0; // <-- THIS IS JUST A PLACEHOLDER!
-}
-
-// Writes a file
-void FAT_Write(file){
-    return 0; // <-- THIS IS JUST A PLACEHOLDER!
-}
+#include "../utils.h"
+#include "../vga.h"
+#include "../../memory/kmalloc.h"
+#include "../../kernel/panic.h"
+#include "../../shell/terminal.h"
 
 // Bootsector stuff! (donated from the OSDev Wiki)
-typedef struct fat_extBS_32
-{
-	// Extended fat32 stuff
+
+// Extended fat32 stuff
+typedef struct FAT_ext32 {
 	u32			table_size_32;
 	u16			extended_flags;
 	u16			fat_version;
@@ -46,23 +26,19 @@ typedef struct fat_extBS_32
 	u32 		volume_id;
 	u8			volume_label[11];
 	u8			fat_type_label[8];
+}__attribute__((packed)) FAT_ext32_t;
  
-}__attribute__((packed)) fat_extBS_32_t;
- 
-typedef struct fat_extBS_16
-{
-	// Extended fat12 and fat16 stuff
+// Extended fat12 and fat16 stuff
+typedef struct FAT_ext16 {
 	u8			bios_drive_num;
 	u8			reserved1;
 	u8			boot_signature;
 	u32			volume_id;
 	u8			volume_label[11];
 	u8			fat_type_label[8];
+}__attribute__((packed)) FAT_ext16_t;
  
-}__attribute__((packed)) fat_extBS_16_t;
- 
-typedef struct fat_BS
-{
+typedef struct FAT_bs {
 	u8 			bootjmp[3];
 	u8 			oem_name[8];
 	u16 		bytes_per_sector;
@@ -78,7 +54,572 @@ typedef struct fat_BS
 	u32 		hidden_sector_count;
 	u32 		total_sectors_32;
  
-	// this will be cast to it's specific type once the driver actually knows what type of FAT this is.
-	u8			extended_section[54];
- 
-}__attribute__((packed)) fat_BS_t;
+	union
+	{
+		FAT_ext16_t ext_bs_16;
+		FAT_ext32_t ext_bs_32;
+	};
+}__attribute__((packed)) FAT_bs_t;
+
+typedef struct FAT_date {
+	uint16_t day   : 5;
+	uint16_t month : 4;
+	uint16_t year  : 7;
+} FAT_date_t;
+
+typedef struct FAT_time {
+	uint16_t second : 5;
+	uint16_t minute : 6;
+	uint16_t hour   : 5;
+} FAT_time_t;
+
+typedef struct FAT_dir_entry {
+	uint8_t    name[11];
+	uint8_t    attr;
+	uint8_t    ntres;
+	uint8_t    creation_time_hundreth;
+	FAT_time_t creation_time;
+	FAT_date_t creation_date;
+	FAT_date_t last_access_date;
+	uint16_t   first_cluster_hi;
+	FAT_time_t write_time;
+	FAT_date_t write_date;
+	uint16_t   first_cluster_lo;
+	uint32_t   file_size;
+} __attribute__((packed)) FAT_dir_entry_t;
+
+static bool is_power_of_two(uint32_t value) {
+	if (value == 0)
+		return false;
+	return (value & (value - 1)) == 0;	
+}
+
+static int min(int a, int b) {
+	return a < b ? a : b;
+}
+
+static void read_entry_name(const FAT_dir_entry_t* entry, char* buffer) {
+	int len = 0;
+
+	// main part of name without trailing spaces
+	memcpy(buffer, entry->name, 8);
+	for (len = 8; len > 0; len--) {
+		if (buffer[len - 1] != ' ') {
+			break;
+		}
+	}
+
+	// add file extension
+	if (entry->name[8] != ' ') {
+		buffer[len++] = '.';
+		for (int j = 8; j < 11; j++) {
+			if (entry->name[j] == ' ') {
+				break;
+			}
+			buffer[len++] = entry->name[j];
+		}
+	}
+
+	buffer[len] = 0;
+}
+
+// This actually makes the fat stuff work.
+FAT_filesystem_t* FAT_Init(storage_device_t* storage_device) {
+	uint8_t* sector_buffer = kmalloc(storage_device->sector_size);
+	if (sector_buffer == NULL)
+		return NULL;
+
+	if (!storage_device->read_sectors(storage_device, sector_buffer, 0, 1))
+		goto error_label;
+
+	const FAT_bs_t* bs = (const FAT_bs_t*)sector_buffer;
+
+	// Jump code must be of form 0xEB??90 or 0xE9????
+	if (!((bs->bootjmp[0] == 0xEB && bs->bootjmp[2] == 0x90) || (bs->bootjmp[0] == 0xE9)))
+		goto error_label;
+	
+	if (!is_power_of_two(bs->bytes_per_sector) || bs->bytes_per_sector < 512 || bs->bytes_per_sector > 4096)
+		goto error_label;
+
+	if (!is_power_of_two(bs->sectors_per_cluster) || bs->sectors_per_cluster > 128)
+		goto error_label;
+
+	if (bs->reserved_sector_count == 0)
+		goto error_label;
+
+	if (bs->table_count == 0)
+		goto error_label;
+
+	switch (bs->media_type)
+	{
+		case 0xF0: case 0xF8: case 0xF9:
+		case 0xFA: case 0xFB: case 0xFC:
+		case 0xFD: case 0xFE: case 0xFF:
+			break;
+		default:
+			goto error_label;
+	}
+
+	uint32_t first_fat_sector = bs->reserved_sector_count;
+	uint32_t fat_sector_count = bs->table_size_16 ? bs->table_size_16 : bs->ext_bs_32.table_size_32;
+
+	uint32_t root_sector_count = (bs->root_entry_count * 32 + (bs->bytes_per_sector - 1)) / bs->bytes_per_sector;
+	uint32_t total_sector_count = bs->total_sectors_16 ? bs->total_sectors_16 : bs->total_sectors_32;
+
+	uint32_t first_data_sector = bs->reserved_sector_count + (bs->table_count * fat_sector_count) + root_sector_count;
+
+	uint32_t data_sector_count = total_sector_count - first_data_sector;
+	uint32_t cluster_count = data_sector_count / bs->sectors_per_cluster;
+
+	uint8_t* fat_sector_buffer = kmalloc(bs->bytes_per_sector * 2);
+	if (fat_sector_buffer == NULL) {
+		goto error_label;
+	}
+
+	FAT_filesystem_t* result = kmalloc(sizeof(FAT_filesystem_t));
+	if (result == NULL) {
+		kfree(fat_sector_buffer);
+		goto error_label;
+	}
+
+	result->storage_device = storage_device;
+	result->fat_type = (cluster_count < 4085) ? FAT12 : (cluster_count < 65525) ? FAT16 : FAT32;
+
+	result->root_file.filesystem = result;
+	result->root_file.is_directory = true;
+
+	switch (result->fat_type)
+	{
+		case FAT12:
+		case FAT16:
+			result->fat16.root_sector = bs->reserved_sector_count + (bs->table_count * fat_sector_count);
+			result->fat16.root_entry_count = bs->root_entry_count;
+			break;
+		case FAT32:
+			result->root_file.first_cluster = bs->ext_bs_32.root_cluster;
+			break;
+		default:
+			panic("NOT REACHED");
+	}
+
+	result->bytes_per_sector = bs->bytes_per_sector;
+	result->sectors_per_cluster = bs->sectors_per_cluster;
+
+	result->first_data_sector = first_data_sector;
+	result->first_fat_sector = first_fat_sector;
+
+	result->cluster_count = cluster_count;
+
+	result->sector_buffer = fat_sector_buffer;
+	result->sector_buffer_sector = 0;
+
+	kfree(sector_buffer);
+	return result;
+
+error_label:
+	kfree(sector_buffer);
+	return NULL;
+}
+
+FAT_file_t* FAT_OpenAbsolute(FAT_filesystem_t* filesystem, const char* path) {
+	FAT_file_t* file = &filesystem->root_file;
+
+	char buffer[512];
+	while (*path) {
+		size_t i = 0;
+		while (*path && *path != '/') {
+			buffer[i++] = *path;
+			path++;
+		}
+		if (*path) {
+			path++;
+		}
+		buffer[i] = '\0';
+
+		if (i == 0) {
+			continue;
+		}
+
+		FAT_file_t* temp = file;
+		file = FAT_Open(file, buffer);
+		FAT_Close(temp);
+
+		if (file == NULL) {
+			return NULL;
+		}
+	}
+
+	return file;
+}
+
+static bool for_each_fat_dir_entry(const uint8_t* buffer, size_t buffer_len, void* data, bool(*callback)(const FAT_dir_entry_t*, void*)) {
+	for (uint32_t offset = 0; offset < buffer_len; offset += sizeof(FAT_dir_entry_t)) {
+		const FAT_dir_entry_t* entry = (const FAT_dir_entry_t*)(buffer + offset);
+
+		// Last entry
+		if (entry->name[0] == 0) {
+			return true;
+		}
+
+		// Unused entry
+		if (entry->name[0] == 0xE5) {
+			continue;
+		}
+
+		// Skip long name entries
+		if ((entry->attr & 0x3F) == 0x0F) {
+			continue;
+		}
+
+		if (callback(entry, data)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+typedef struct search_info {
+	const char* name;
+	FAT_file_t* file;
+	bool found;
+} search_info_t;
+
+static bool find_fat_dir_entry_by_name(const FAT_dir_entry_t* entry, void* data) {
+	char entry_name[13];
+	read_entry_name(entry, entry_name);
+
+	search_info_t* info = (search_info_t*)data;
+	if (strlen(info->name) != strlen(entry_name)) {
+		return false;
+	}
+	for (size_t i = 0; info->name[i]; i++) {
+		if (tolower(entry_name[i]) != tolower(info->name[i])) {
+			return false;
+		}
+	}
+
+	info->file->first_cluster = ((uint32_t)entry->first_cluster_hi << 16) | entry->first_cluster_lo;
+	info->file->file_size = entry->file_size;
+	info->file->is_directory = !!(entry->attr & 0x10);
+	info->found = true;
+
+	return true;
+}
+
+static bool is_valid_cluster(FAT_filesystem_t* filesystem, uint32_t cluster) {
+	if (cluster < 2 || cluster >= filesystem->cluster_count) {
+		return false;
+	}
+	return true;
+}
+
+static uint32_t get_next_cluster(FAT_filesystem_t* filesystem, uint32_t cluster) {
+	if (!is_valid_cluster(filesystem, cluster)) {
+		panic("NOT REACHED");
+	}
+
+	uint32_t fat_byte_offset;
+	uint32_t ent_offset;
+
+	switch (filesystem->fat_type)
+	{
+		case FAT12:
+			fat_byte_offset = cluster + (cluster / 2);
+			ent_offset = fat_byte_offset % filesystem->bytes_per_sector;
+			break;
+		case FAT16:
+			fat_byte_offset = cluster * sizeof(uint16_t);
+			ent_offset = (fat_byte_offset % filesystem->bytes_per_sector) / sizeof(uint16_t);
+			break;
+		case FAT32:
+			fat_byte_offset = cluster * sizeof(uint32_t);
+			ent_offset = (fat_byte_offset % filesystem->bytes_per_sector) / sizeof(uint32_t);
+			break;
+		default:
+			panic("NOT REACHED");
+	}
+
+	uint32_t target_sector = filesystem->first_fat_sector + fat_byte_offset / filesystem->bytes_per_sector;
+	if (filesystem->sector_buffer_sector != target_sector) {
+		if (!filesystem->storage_device->read_sectors(filesystem->storage_device, filesystem->sector_buffer, target_sector, 2)) {
+			dprintln("could not read file allocation table");
+			return 0;
+		}
+		filesystem->sector_buffer_sector = target_sector;
+	}
+
+	switch (filesystem->fat_type)
+	{
+		case FAT12:
+			uint16_t next = (filesystem->sector_buffer[ent_offset + 1] << 8) | filesystem->sector_buffer[ent_offset];
+			return cluster % 2 ? next >> 4 : next & 0xFFF;
+		case FAT16:
+			return ((uint16_t*)filesystem->sector_buffer)[ent_offset];
+		case FAT32:
+			return ((uint32_t*)filesystem->sector_buffer)[ent_offset];
+	}
+
+	panic("NOT REACHED");
+}
+
+FAT_file_t* FAT_Open(FAT_file_t* parent, const char* name) {
+	FAT_filesystem_t* filesystem = parent->filesystem;
+
+	if (!parent->is_directory) {
+		dprintln("trying to open file from non-directory");
+		return NULL;
+	}
+
+	if (filesystem->bytes_per_sector != filesystem->storage_device->sector_size) {
+		dprintln("FAT sector size does not match with its underlying storage, not supported");
+		return NULL;
+	}
+
+	FAT_file_t* file = kmalloc(sizeof(FAT_file_t));
+	if (file == NULL) {
+		dprintln("could not allocate memory for FAT file");
+		return NULL;
+	}
+	file->filesystem = filesystem;
+	file->first_cluster = 0;
+
+	search_info_t info;
+	info.name = name;
+	info.file = file;
+	info.found = false;
+
+	if ((filesystem->fat_type == FAT12 || filesystem->fat_type == FAT16) && parent == &filesystem->root_file) {
+		uint8_t* buffer = kmalloc(filesystem->bytes_per_sector);
+		if (buffer == NULL) {
+			dprintln("could not allocate memory for FAT sector");
+			kfree(file);
+			return NULL;
+		}
+
+		uint32_t entries_per_sector = filesystem->bytes_per_sector / sizeof(FAT_dir_entry_t);
+		for (uint32_t i = 0; i < filesystem->fat16.root_entry_count; i++) {
+			uint32_t sector = filesystem->fat16.root_sector + (i / entries_per_sector);
+			if (!filesystem->storage_device->read_sectors(filesystem->storage_device, buffer, sector, 1)) {
+				dprintln("could not read root directory");
+				break;
+			}
+
+			uint32_t buffer_len = min(filesystem->bytes_per_sector, (filesystem->fat16.root_entry_count - i) * sizeof(FAT_dir_entry_t));
+			if (for_each_fat_dir_entry(buffer, buffer_len, &info, find_fat_dir_entry_by_name)) {
+				break;
+			}
+		}
+
+		kfree(buffer);
+	}
+	else {
+		uint32_t cluster_size = filesystem->bytes_per_sector * filesystem->sectors_per_cluster;
+		uint8_t* buffer = kmalloc(cluster_size);
+		if (buffer == NULL) {
+			dprintln("could not allocate memory for FAT cluster");
+			kfree(file);
+			return NULL;
+		}
+
+		uint32_t cluster = parent->first_cluster;
+		while (is_valid_cluster(filesystem, cluster)) {
+			uint32_t cluster_start_sector = ((cluster - 2) * filesystem->sectors_per_cluster) + filesystem->first_data_sector;
+			if (!filesystem->storage_device->read_sectors(filesystem->storage_device, buffer, cluster_start_sector, filesystem->sectors_per_cluster)) {
+				dprintln("could not read FAT cluster");
+				break;
+			}
+
+			if (for_each_fat_dir_entry(buffer, cluster_size, &info, find_fat_dir_entry_by_name)) {
+				break;
+			}
+		}
+
+		kfree(buffer);
+	}
+
+	if (info.found) {
+		info.file->first_cluster &= 0xFFFF;
+		return info.file;
+	}
+
+	kfree(file);
+	return NULL;
+}
+
+void FAT_Close(FAT_file_t* file) {
+	// Root file cannot be freed as that is not allocated with kmalloc
+	if (file != &file->filesystem->root_file) {
+		kfree(file);
+	}
+}
+
+size_t FAT_Read(FAT_file_t* file, size_t offset, void* dest_buffer, size_t buffer_len) {
+	FAT_filesystem_t* filesystem = file->filesystem;
+
+	if (file->is_directory) {
+		dprintln("trying to read from directory");
+		return 0;
+	}
+
+	if (offset >= file->file_size) {
+		return 0;
+	}
+
+	if (offset + buffer_len > file->file_size) {
+		buffer_len = file->file_size - offset;
+	}
+
+	if (filesystem->bytes_per_sector != filesystem->storage_device->sector_size) {
+		dprintln("FAT sector size does not match with its underlying storage, not supported");
+		return 0;
+	}
+
+	uint32_t cluster_size = filesystem->bytes_per_sector * filesystem->sectors_per_cluster;
+
+	uint8_t* buffer = kmalloc(cluster_size);
+	if (buffer == NULL) {
+		dprintln("could not allocate memory for FAT cluster");
+	}
+
+	uint32_t cluster = file->first_cluster;
+	for (uint32_t i = 0; i < offset / cluster_size; i++) {
+		if (!is_valid_cluster(filesystem, cluster)) {
+			dprintln("corrupted FAT file, no allocated cluster");
+			kfree(buffer);
+			return 0;
+		}
+		cluster = get_next_cluster(filesystem, cluster);
+	}
+
+	uint32_t bytes_copied = 0;
+	while (bytes_copied < buffer_len) {
+		if (!is_valid_cluster(filesystem, cluster)) {
+			dprintln("corrupted FAT file, no allocated cluster");
+			break;
+		}
+
+		uint32_t cluster_offset = offset % cluster_size;
+
+		uint32_t cluster_start_sector = ((cluster - 2) * filesystem->sectors_per_cluster) + filesystem->first_data_sector;
+		if (!filesystem->storage_device->read_sectors(filesystem->storage_device, buffer, cluster_start_sector, filesystem->sectors_per_cluster)) {
+			dprintln("could not read file data directory");
+			break;
+		}
+
+		uint32_t to_copy = min(cluster_size - cluster_offset, buffer_len);
+		memcpy((uint8_t*)dest_buffer + bytes_copied, buffer + cluster_offset, to_copy);
+
+		cluster = get_next_cluster(filesystem, cluster);
+
+		bytes_copied += to_copy;
+		offset += to_copy;
+	}
+
+	kfree(buffer);
+	return bytes_copied;
+}
+
+typedef struct list_info {
+	char** names;
+	size_t name_count;
+} list_info_t;
+
+static bool append_fat_entry_name(const FAT_dir_entry_t* entry, void* data) {
+	list_info_t* info = (list_info_t*)data;
+
+	char** new_names = kmalloc((info->name_count + 1) * sizeof(char*));
+	if (new_names == NULL) {
+		return true;
+	}
+
+	char* entry_name = kmalloc(13);
+	if (entry_name == NULL) {
+		kfree(new_names);
+		return true;
+	}
+	read_entry_name(entry, entry_name);
+
+	for (size_t i = 0; i < info->name_count; i++) {
+		new_names[i] = info->names[i];
+	}
+	new_names[info->name_count] = entry_name;
+
+	kfree(info->names);
+	info->names = new_names;
+	info->name_count++;
+
+	return false;
+}
+
+size_t FAT_ListFiles(FAT_file_t* parent, char*** names_output) {
+	FAT_filesystem_t* filesystem = parent->filesystem;
+
+	if (!parent->is_directory) {
+		dprintln("trying to list files from non-directory");
+		return 0;
+	}
+
+	if (filesystem->bytes_per_sector != filesystem->storage_device->sector_size) {
+		dprintln("FAT sector size does not match with its underlying storage, not supported");
+		return 0;
+	}
+
+	list_info_t info;
+	info.names = NULL;
+	info.name_count = 0;
+
+	if ((filesystem->fat_type == FAT12 || filesystem->fat_type == FAT16) && parent == &filesystem->root_file) {
+		uint8_t* buffer = kmalloc(filesystem->bytes_per_sector);
+		if (buffer == NULL) {
+			dprintln("could not allocate memory for FAT sector");
+			return 0;
+		}
+
+		uint32_t root_total_bytes = filesystem->fat16.root_entry_count * sizeof(FAT_dir_entry_t);
+		uint32_t root_bytes_done = 0;
+		for (uint32_t i = 0; root_bytes_done < root_total_bytes; i++) {
+			if (!filesystem->storage_device->read_sectors(filesystem->storage_device, buffer, filesystem->fat16.root_sector + i, 1)) {
+				dprintln("could not read root directory");
+				break;
+			}
+
+			uint32_t buffer_len = min(filesystem->bytes_per_sector, root_total_bytes - root_bytes_done);
+			if (for_each_fat_dir_entry(buffer, buffer_len, &info, append_fat_entry_name)) {
+				break;
+			}
+
+			root_bytes_done += buffer_len;
+		}
+
+		kfree(buffer);
+	}
+	else {
+		uint8_t* buffer = kmalloc(filesystem->bytes_per_sector * filesystem->sectors_per_cluster);
+		if (buffer == NULL) {
+			dprintln("could not allocate memory for FAT cluster");
+			return 0;
+		}
+
+		uint32_t cluster = parent->first_cluster;
+		while (is_valid_cluster(filesystem, cluster)) {
+			uint32_t cluster_start_sector = ((cluster - 2) * filesystem->sectors_per_cluster) + filesystem->first_data_sector;
+			if (!filesystem->storage_device->read_sectors(filesystem->storage_device, buffer, cluster_start_sector, filesystem->sectors_per_cluster)) {
+				dprintln("could not read FAT cluster");
+				break;
+			}
+
+			u32 cluster_size = filesystem->bytes_per_sector * filesystem->sectors_per_cluster;
+			if (for_each_fat_dir_entry(buffer, cluster_size, &info, append_fat_entry_name)) {
+				break;
+			}
+
+			cluster = get_next_cluster(filesystem, cluster);
+		}
+
+		kfree(buffer);
+	}
+
+	*names_output = info.names;
+	return info.name_count;
+}

--- a/src/drivers/filesystem/fat.h
+++ b/src/drivers/filesystem/fat.h
@@ -1,14 +1,88 @@
-// TODO: Add proper code and headers
-// This is primarily a port of one FAT driver I found on GitHub so credit to ApplePy.
-#ifndef FAT_H_
-#define FAT_H_
+#pragma once
 
-// Placeholder //
+#include "../storage/device.h"
 
-// Do the fat functions, which is just instructions from the FAT.C file pasted in here yippee
-void FAT_Init();
-void FAT_Open(file);
-void FAT_Read(file);
-void FAT_Write(file);
+typedef enum FAT_type {
+	FAT12,
+	FAT16,
+	FAT32
+} FAT_type_t;
 
-#endif
+typedef struct FAT_file {
+	struct FAT_filesystem* filesystem;
+	uint32_t first_cluster;
+	uint32_t file_size;
+	bool is_directory;
+} FAT_file_t;
+
+typedef struct FAT_filesystem {
+	storage_device_t* storage_device;
+
+	FAT_type_t fat_type;
+
+	// Only used in FAT12 and FAT16
+	struct {
+		uint32_t root_sector;
+		uint32_t root_entry_count;
+	} fat16;
+
+	uint32_t bytes_per_sector;
+	uint32_t sectors_per_cluster;
+
+	uint32_t first_fat_sector;
+	uint32_t first_data_sector;
+
+	uint32_t cluster_count;
+
+	uint8_t* sector_buffer;
+	uint32_t sector_buffer_sector;
+
+	FAT_file_t root_file;
+} FAT_filesystem_t;
+
+// Try to initialize FAT filesystem from storage device
+//   on success:
+//     return pointer to FAT filesystem
+//   on error:
+//     return NULL
+FAT_filesystem_t* FAT_Init(storage_device_t*);
+
+// Open file with absolute path from a FAT filesystem
+// Path separator '/'s is used while parsing
+//   on success
+//     return a pointer to FAT file
+//   file not found:
+//     return NULL
+//   on error:
+//     return NULL
+FAT_file_t* FAT_OpenAbsolute(FAT_filesystem_t*, const char* path);
+
+// Look for a file with name from parent file
+// Open files MUST be closed with FAT_Close
+//   on success
+//     return a pointer to FAT file
+//   file not found:
+//     return NULL
+//   on error:
+//     return NULL
+FAT_file_t* FAT_Open(FAT_file_t* parent, const char* name);
+
+// Close a FAT file
+void FAT_Close(FAT_file_t* file);
+
+// Read bytes from a FAT file from given offset
+//   on success
+//     return the number of bytes read
+//   on end of file
+//     return 0
+//   on error:
+//     return 0
+size_t FAT_Read(FAT_file_t* file, size_t offset, void* buffer, size_t buffer_len);
+
+// List all files from parent into the output names
+// Output names is pointer to list of char pointers
+// All entries in *names_output and *names_output itself MUST be deleted with kfree
+//   always returns the number of entries in *names_output
+size_t FAT_ListFiles(FAT_file_t* parent, char*** names_output);
+
+//void FAT_Write(file);

--- a/src/drivers/storage/device.h
+++ b/src/drivers/storage/device.h
@@ -3,13 +3,13 @@
 #include "../types.h"
 #include <stdbool.h>
 
-typedef struct storage_device_t {
+typedef struct storage_device {
     bool (*read_sectors)(void* self, void* buffer, u64 sector, u64 count);
     bool (*write_sectors)(void* self, const void* buffer, u64 sector, u64 count);
     u64 sector_count;
     u32 sector_size;
     const char* model;
-    struct storage_device_t** partitions;
+    struct storage_device** partitions;
     u32 partition_count;
 } storage_device_t;
 

--- a/src/drivers/storage/partition.c
+++ b/src/drivers/storage/partition.c
@@ -18,7 +18,7 @@ static bool partition_read_sectors(void* self, void* buffer, u64 sector, u64 cou
         dprintln("Partition read: sector out of range");
         return false;
     }
-    return device->disk->read_sectors(device, buffer, device->first_sector + sector, count);
+    return device->disk->read_sectors(device->disk, buffer, device->first_sector + sector, count);
 }
 
 static bool partition_write_sectors(void* self, const void* buffer, u64 sector, u64 count) {

--- a/src/drivers/utils.c
+++ b/src/drivers/utils.c
@@ -117,3 +117,17 @@ char* strcat(char* dest, const char* src) {
     dest[len + i] = '\0';
     return dest;
 }
+
+int tolower(int ch) {
+	if (ch < 'A' || ch > 'Z') {
+		return ch;
+	}
+	return ch - 'A' + 'a';
+}
+
+int toupper(int ch) {
+	if (ch < 'a' || ch > 'z') {
+		return ch;
+	}
+	return ch - 'a' + 'A';
+}

--- a/src/drivers/utils.h
+++ b/src/drivers/utils.h
@@ -17,3 +17,6 @@ int strlen(const char *str);
 int strcmp(const char *str1, const char *str2);
 char* strcpy(char *dest, const char *src);
 char* strcat(char *dest, const char *src);
+
+int tolower(int);
+int toupper(int);

--- a/src/shell/terminal.c
+++ b/src/shell/terminal.c
@@ -102,6 +102,12 @@ void term_putchar_no_cursor_update(char ch, u8 color) {
             s_term_info.col = 0;
             s_term_info.row++;
             break;
+		case '\t':
+			term_putchar_no_cursor_update(' ', color);
+			term_putchar_no_cursor_update(' ', color);
+			term_putchar_no_cursor_update(' ', color);
+			term_putchar_no_cursor_update(' ', color);
+			break;
         default: {
             // put character into buffer
             u32 offset = s_term_info.row * s_term_info.width + s_term_info.col;


### PR DESCRIPTION
This driver is read-only driver for all basic FAT types. There is no long name support.

Please see fat.h for the documentation of the available FAT functions.

Please make comments or question anything weird you find.